### PR TITLE
feat(sdk): surface region + location capture events (v2.4.0)

### DIFF
--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
   
-  s.dependency "BearoundSDK", "~> 2.3.7"
+  s.dependency "BearoundSDK", "~> 2.4.0"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation", "AdSupport"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-05-21
+
+### Changed
+
+- **Native SDKs bumped to v2.4.0**:
+  - iOS: `BearoundSDK ~> 2.4.0`
+  - Android: `com.github.Bearound:bearound-android-sdk:2.4.0`
+- **Location + active scan now strictly beacon-gated.** GPS and active BLE ranging only run while inside a beacon region. Outside the region, only the kernel-level filter scan is on. See native SDK v2.4.0 release notes for full behavior.
+
+### Added
+
+- 3 new event channels surfaced from the native SDKs:
+  - `bearound:beaconRegion` — fires on region enter/exit transitions
+  - `bearound:activeScan` — fires when active scanning (ranging + BLE) toggles
+  - `bearound:locationCapture` — fires `started` when a beacon-triggered GPS window opens and `completed` when it closes (with or without a fix)
+- 3 new listener helpers in `@bearound/react-native-sdk`:
+  - `addBeaconRegionListener(listener)` — `BeaconRegionEvent { type: 'enter' | 'exit' }`
+  - `addActiveScanListener(listener)` — `ActiveScanEvent { isActive: boolean }`
+  - `addLocationCaptureListener(listener)` — `LocationCaptureEvent` discriminated union
+- New exported types: `BeaconRegionEvent`, `ActiveScanEvent`, `CapturedLocation`, `LocationCaptureStartedEvent`, `LocationCaptureCompletedEvent`, `LocationCaptureEvent`.
+- Example app: new **Debug Geofence** section showing live region status, active-scan state, in-flight GPS capture, last captured coordinates, and a rolling log of geofence events with 1 Hz live ages.
+
+### Non-breaking
+
+- All new event channels and listeners are additive. Existing event names and listeners (`addBeaconsListener`, `addSyncLifecycleListener`, etc.) are unchanged.
+
+---
+
 ## [2.3.2] - 2026-02-19
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,5 +75,5 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
   implementation "com.facebook.react:react-android"
-  implementation 'com.github.Bearound:bearound-android-sdk:2.3.7'
+  implementation 'com.github.Bearound:bearound-android-sdk:2.4.0'
 }

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -14,6 +14,7 @@ import io.bearound.sdk.BeAroundSDK
 import io.bearound.sdk.interfaces.BeAroundSDKListener
 import io.bearound.sdk.models.Beacon
 import io.bearound.sdk.models.BeaconMetadata
+import io.bearound.sdk.models.LocationCaptureResult
 import io.bearound.sdk.models.MaxQueuedPayloads
 import io.bearound.sdk.models.ScanPrecision
 import io.bearound.sdk.models.UserProperties
@@ -29,6 +30,10 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     private const val EVENT_BACKGROUND_DETECTION = "bearound:backgroundDetection"
     private const val EVENT_SCANNING = "bearound:scanning"
     private const val EVENT_ERROR = "bearound:error"
+    // v2.4 — region + location capture lifecycle
+    private const val EVENT_BEACON_REGION = "bearound:beaconRegion"
+    private const val EVENT_ACTIVE_SCAN = "bearound:activeScan"
+    private const val EVENT_LOCATION_CAPTURE = "bearound:locationCapture"
   }
 
   private val mainHandler = Handler(Looper.getMainLooper())
@@ -191,6 +196,56 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     val payload = Arguments.createMap()
     payload.putInt("beaconCount", beaconCount)
     sendEvent(EVENT_BACKGROUND_DETECTION, payload)
+  }
+
+  // v2.4 — Beacon region + location capture lifecycle
+
+  override fun onEnterBeaconRegion() {
+    val payload = Arguments.createMap()
+    payload.putString("type", "enter")
+    sendEvent(EVENT_BEACON_REGION, payload)
+  }
+
+  override fun onExitBeaconRegion() {
+    val payload = Arguments.createMap()
+    payload.putString("type", "exit")
+    sendEvent(EVENT_BEACON_REGION, payload)
+  }
+
+  override fun onActiveScanStateChanged(isActive: Boolean) {
+    val payload = Arguments.createMap()
+    payload.putBoolean("isActive", isActive)
+    sendEvent(EVENT_ACTIVE_SCAN, payload)
+  }
+
+  override fun onStartLocationCapture(reason: String) {
+    val payload = Arguments.createMap()
+    payload.putString("type", "started")
+    payload.putString("reason", reason)
+    sendEvent(EVENT_LOCATION_CAPTURE, payload)
+  }
+
+  override fun onCompleteLocationCapture(result: LocationCaptureResult) {
+    val payload = Arguments.createMap()
+    payload.putString("type", "completed")
+    payload.putString("reason", result.reason)
+    payload.putString("outcome", result.outcome)
+    payload.putBoolean("hasFix", result.hasFix)
+    payload.putDouble("timestamp", result.timestamp.time.toDouble())
+
+    result.location?.let { loc ->
+      val locMap = Arguments.createMap()
+      locMap.putDouble("latitude", loc.latitude)
+      locMap.putDouble("longitude", loc.longitude)
+      if (loc.hasAccuracy()) locMap.putDouble("horizontalAccuracy", loc.accuracy.toDouble())
+      if (loc.hasAltitude()) locMap.putDouble("altitude", loc.altitude)
+      if (loc.hasSpeed()) locMap.putDouble("speed", loc.speed.toDouble())
+      if (loc.hasBearing()) locMap.putDouble("course", loc.bearing.toDouble())
+      locMap.putDouble("timestamp", loc.time.toDouble())
+      payload.putMap("location", locMap)
+    }
+
+    sendEvent(EVENT_LOCATION_CAPTURE, payload)
   }
 
   private fun mapUserProperties(args: ReadableMap): UserProperties {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -13,6 +13,9 @@ buildscript {
     }
     allprojects {
       repositories {
+        // mavenLocal() first so we pick up locally-published native SDK snapshots
+        // (e.g. bearound-android-sdk:2.4.0 before it lands on JitPack).
+        mavenLocal()
         google()
         mavenCentral()
         maven { url 'https://jitpack.io' }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -13,9 +13,6 @@ buildscript {
     }
     allprojects {
       repositories {
-        // mavenLocal() first so we pick up locally-published native SDK snapshots
-        // (e.g. bearound-android-sdk:2.4.0 before it lands on JitPack).
-        mavenLocal()
         google()
         mavenCentral()
         maven { url 'https://jitpack.io' }

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const { getDefaultConfig } = require('@react-native/metro-config');
-const { withMetroConfig } = require('react-native-monorepo-config');
 
 const root = path.resolve(__dirname, '..');
 
@@ -8,9 +7,16 @@ const root = path.resolve(__dirname, '..');
  * Metro configuration
  * https://facebook.github.io/metro/docs/configuration
  *
- * @type {import('metro-config').MetroConfig}
+ * Uses dynamic import for `react-native-monorepo-config` because the package
+ * publishes as ESM-only and `require()` of ESM is gated by a Node flag until
+ * Node 23. Metro accepts a Promise-resolved config.
+ *
+ * @type {Promise<import('metro-config').MetroConfig>}
  */
-module.exports = withMetroConfig(getDefaultConfig(__dirname), {
-  root,
-  dirname: __dirname,
-});
+module.exports = (async () => {
+  const { withMetroConfig } = await import('react-native-monorepo-config');
+  return withMetroConfig(getDefaultConfig(__dirname), {
+    root,
+    dirname: __dirname,
+  });
+})();

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -179,6 +179,12 @@ export default function App() {
 
   // v2.4 — Geofence Debug state
   const [isInBeaconRegion, setIsInBeaconRegion] = useState(false);
+  const [lastEnteredRegionAt, setLastEnteredRegionAt] = useState<number | null>(
+    null
+  );
+  const [lastExitedRegionAt, setLastExitedRegionAt] = useState<number | null>(
+    null
+  );
   const [isActiveScan, setIsActiveScan] = useState(false);
   const [isCapturingLocation, setIsCapturingLocation] = useState(false);
   const [lastCaptureOpenReason, setLastCaptureOpenReason] = useState('—');
@@ -188,6 +194,7 @@ export default function App() {
   >(null);
   const [lastCapturedLocation, setLastCapturedLocation] =
     useState<CapturedLocation | null>(null);
+  const [locationCaptureCount, setLocationCaptureCount] = useState(0);
   const [geofenceEvents, setGeofenceEvents] = useState<GeofenceEventEntry[]>(
     []
   );
@@ -332,6 +339,16 @@ export default function App() {
     try {
       await configureSdk();
       await BeAround.startScanning();
+      // Reset geofence/capture session counters so each scan starts clean
+      setGeofenceEvents([]);
+      setLocationCaptureCount(0);
+      setLastEnteredRegionAt(null);
+      setLastExitedRegionAt(null);
+      setLastCaptureOpenReason('—');
+      setLastCaptureOutcome('—');
+      setLastCapturedLocation(null);
+      setLastCaptureCompletedAt(null);
+
       const scanning = await BeAround.isScanning();
       setIsScanning(scanning);
       setStatusMessage(scanning ? 'Scaneando...' : 'Parado');
@@ -409,12 +426,14 @@ export default function App() {
     const regionSub = addBeaconRegionListener((event) => {
       if (event.type === 'enter') {
         setIsInBeaconRegion(true);
+        setLastEnteredRegionAt(Date.now());
         pushGeofenceEvent(
           'region-enter',
           'iOS/Android reportou entrada na zona do beacon'
         );
       } else {
         setIsInBeaconRegion(false);
+        setLastExitedRegionAt(Date.now());
         pushGeofenceEvent('region-exit', 'Saiu da zona do beacon');
       }
     });
@@ -442,6 +461,7 @@ export default function App() {
         setLastCaptureOutcome(event.outcome);
         setLastCaptureCompletedAt(event.timestamp || Date.now());
         setLastCapturedLocation(event.location ?? null);
+        setLocationCaptureCount((prev) => prev + 1);
         if (event.location) {
           const acc = event.location.horizontalAccuracy ?? -1;
           pushGeofenceEvent(
@@ -587,11 +607,29 @@ export default function App() {
               ) : null}
             </View>
 
+            <GpsPolicyBanner
+              isInZone={isInBeaconRegion}
+              isCapturing={isCapturingLocation}
+              captureCount={locationCaptureCount}
+            />
+
             <InfoRow
               label="Zona do beacon"
               value={isInBeaconRegion ? 'DENTRO' : 'fora'}
               valueColor={isInBeaconRegion ? '#4caf50' : '#9e9e9e'}
             />
+            {lastEnteredRegionAt ? (
+              <InfoRow
+                label="Entrou às"
+                value={`${formatTime(new Date(lastEnteredRegionAt))}  (${formatAge(nowMs - lastEnteredRegionAt)})`}
+              />
+            ) : null}
+            {lastExitedRegionAt ? (
+              <InfoRow
+                label="Saiu às"
+                value={`${formatTime(new Date(lastExitedRegionAt))}  (${formatAge(nowMs - lastExitedRegionAt)})`}
+              />
+            ) : null}
             <InfoRow
               label="Scan ativo"
               value={isActiveScan ? 'LIGADO' : 'desligado'}
@@ -837,6 +875,52 @@ function permissionColor(status: string) {
     return '#9e9e9e';
   }
   return '#9e9e9e';
+}
+
+function GpsPolicyBanner({
+  isInZone,
+  isCapturing,
+  captureCount,
+}: {
+  isInZone: boolean;
+  isCapturing: boolean;
+  captureCount: number;
+}) {
+  const bg = isInZone ? '#0f2b14' : '#2a0f0f';
+  const border = isInZone ? '#2e7d32' : '#c62828';
+  const titleColor = isInZone ? '#a5d6a7' : '#ef9a9a';
+  const emoji = isInZone ? '✅' : '⛔';
+  const title = isInZone ? 'GPS LIBERADO' : 'GPS BLOQUEADO';
+  const body = !isInZone
+    ? 'Sem beacon detectado. Localização NÃO está sendo lida.'
+    : isCapturing
+      ? 'Capturando agora — janela aberta porque você entrou na zona.'
+      : 'Dentro da zona. GPS já capturou o que precisava; agora está em standby.';
+
+  return (
+    <View
+      style={[
+        styles.policyBanner,
+        { backgroundColor: bg, borderColor: border },
+      ]}
+    >
+      <View style={styles.policyHeader}>
+        <Text style={styles.policyEmoji}>{emoji}</Text>
+        <Text style={[styles.policyTitle, { color: titleColor }]}>{title}</Text>
+      </View>
+      <Text style={[styles.policyBody, { color: titleColor }]}>{body}</Text>
+      <View style={styles.policyCounterRow}>
+        <Text style={styles.policyCounterLabel}>📊 Capturas nesta sessão:</Text>
+        <Text style={styles.policyCounterValue}>{captureCount}</Text>
+      </View>
+      <View style={styles.policyCounterRow}>
+        <Text style={styles.policyCounterLabel}>🛡️ Capturas fora da zona:</Text>
+        <Text style={[styles.policyCounterValue, { color: '#a5d6a7' }]}>
+          0 ✓
+        </Text>
+      </View>
+    </View>
+  );
 }
 
 function InfoRow({
@@ -1116,6 +1200,48 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 12,
+  },
+  policyBanner: {
+    borderRadius: 8,
+    borderWidth: 1,
+    padding: 12,
+    marginBottom: 12,
+  },
+  policyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  policyEmoji: {
+    fontSize: 18,
+    marginRight: 8,
+  },
+  policyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  policyBody: {
+    fontSize: 12,
+    marginBottom: 6,
+  },
+  policyCounterRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    marginTop: 4,
+  },
+  policyCounterLabel: {
+    color: '#bdbdbd',
+    fontSize: 11,
+  },
+  policyCounterValue: {
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: '700',
   },
   clearLogText: {
     color: '#bdbdbd',

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -18,12 +18,16 @@ import {
   addScanningListener,
   addSyncLifecycleListener,
   addBackgroundDetectionListener,
+  addBeaconRegionListener,
+  addActiveScanListener,
+  addLocationCaptureListener,
   checkPermissions,
   ensurePermissions,
   ScanPrecision,
   MaxQueuedPayloads,
   type Beacon,
   type BeaconProximity,
+  type CapturedLocation,
   type PermissionResult,
 } from '@bearound/react-native-sdk';
 
@@ -96,6 +100,65 @@ const proximityColor = (value: BeaconProximity) => {
 const formatTime = (date: Date) =>
   date.toLocaleTimeString('pt-BR', { hour12: false });
 
+type GeofenceEventKind =
+  | 'region-enter'
+  | 'region-exit'
+  | 'scan-active'
+  | 'scan-paused'
+  | 'capture-started'
+  | 'capture-fix'
+  | 'capture-no-fix';
+
+type GeofenceEventEntry = {
+  id: string;
+  kind: GeofenceEventKind;
+  timestamp: number;
+  detail: string;
+};
+
+const geofenceEventTitle = (kind: GeofenceEventKind) => {
+  switch (kind) {
+    case 'region-enter':
+      return 'ENTROU NA ZONA';
+    case 'region-exit':
+      return 'SAIU DA ZONA';
+    case 'scan-active':
+      return 'SCAN LIGADO';
+    case 'scan-paused':
+      return 'SCAN PAUSADO';
+    case 'capture-started':
+      return 'GPS DISPARADO';
+    case 'capture-fix':
+      return 'FIX OK';
+    case 'capture-no-fix':
+      return 'SEM FIX';
+  }
+};
+
+const geofenceEventColor = (kind: GeofenceEventKind) => {
+  switch (kind) {
+    case 'region-enter':
+    case 'scan-active':
+    case 'capture-fix':
+      return '#4caf50';
+    case 'region-exit':
+      return '#ff9800';
+    case 'scan-paused':
+      return '#9e9e9e';
+    case 'capture-started':
+      return '#2196f3';
+    case 'capture-no-fix':
+      return '#f44336';
+  }
+};
+
+const formatAge = (ms: number) => {
+  const sec = Math.max(0, Math.floor(ms / 1000));
+  if (sec < 60) return `${sec}s atrás`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}min ${sec % 60}s atrás`;
+  return `${Math.floor(sec / 3600)}h ${Math.floor((sec % 3600) / 60)}min atrás`;
+};
+
 export default function App() {
   const [scanPrecision, setScanPrecision] = useState(ScanPrecision.MEDIUM);
   const [maxQueuedPayloads, setMaxQueuedPayloads] = useState(
@@ -113,6 +176,44 @@ export default function App() {
   const [beacons, setBeacons] = useState<Beacon[]>([]);
   const [lastScanTime, setLastScanTime] = useState<Date | null>(null);
   const [lastError, setLastError] = useState<string | null>(null);
+
+  // v2.4 — Geofence Debug state
+  const [isInBeaconRegion, setIsInBeaconRegion] = useState(false);
+  const [isActiveScan, setIsActiveScan] = useState(false);
+  const [isCapturingLocation, setIsCapturingLocation] = useState(false);
+  const [lastCaptureOpenReason, setLastCaptureOpenReason] = useState('—');
+  const [lastCaptureOutcome, setLastCaptureOutcome] = useState('—');
+  const [lastCaptureCompletedAt, setLastCaptureCompletedAt] = useState<
+    number | null
+  >(null);
+  const [lastCapturedLocation, setLastCapturedLocation] =
+    useState<CapturedLocation | null>(null);
+  const [geofenceEvents, setGeofenceEvents] = useState<GeofenceEventEntry[]>(
+    []
+  );
+  // 1Hz tick so live "X seg atrás" ages render in real time.
+  const [nowMs, setNowMs] = useState(Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const pushGeofenceEvent = useCallback(
+    (kind: GeofenceEventKind, detail: string) => {
+      setGeofenceEvents((prev) => {
+        const entry: GeofenceEventEntry = {
+          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          kind,
+          timestamp: Date.now(),
+          detail,
+        };
+        return [entry, ...prev].slice(0, 30);
+      });
+    },
+    []
+  );
+
+  const clearGeofenceLog = useCallback(() => setGeofenceEvents([]), []);
 
   const precisionLabel = useMemo(() => {
     switch (scanPrecision) {
@@ -305,14 +406,70 @@ export default function App() {
       setStatusMessage(`Erro: ${error.message}`);
     });
 
+    const regionSub = addBeaconRegionListener((event) => {
+      if (event.type === 'enter') {
+        setIsInBeaconRegion(true);
+        pushGeofenceEvent(
+          'region-enter',
+          'iOS/Android reportou entrada na zona do beacon'
+        );
+      } else {
+        setIsInBeaconRegion(false);
+        pushGeofenceEvent('region-exit', 'Saiu da zona do beacon');
+      }
+    });
+
+    const activeScanSub = addActiveScanListener((event) => {
+      setIsActiveScan(event.isActive);
+      pushGeofenceEvent(
+        event.isActive ? 'scan-active' : 'scan-paused',
+        event.isActive
+          ? 'Scan ativo (ranging + BLE) LIGADO'
+          : 'Scan ativo DESLIGADO — só monitoring de região'
+      );
+    });
+
+    const locationCaptureSub = addLocationCaptureListener((event) => {
+      if (event.type === 'started') {
+        setIsCapturingLocation(true);
+        setLastCaptureOpenReason(event.reason);
+        pushGeofenceEvent(
+          'capture-started',
+          `Janela GPS aberta — motivo: ${event.reason}`
+        );
+      } else {
+        setIsCapturingLocation(false);
+        setLastCaptureOutcome(event.outcome);
+        setLastCaptureCompletedAt(event.timestamp || Date.now());
+        setLastCapturedLocation(event.location ?? null);
+        if (event.location) {
+          const acc = event.location.horizontalAccuracy ?? -1;
+          pushGeofenceEvent(
+            'capture-fix',
+            `Fix: ${event.location.latitude.toFixed(5)}, ${event.location.longitude.toFixed(
+              5
+            )} ±${acc >= 0 ? Math.round(acc) : '?'}m | abriu: ${event.reason} | fechou: ${event.outcome}`
+          );
+        } else {
+          pushGeofenceEvent(
+            'capture-no-fix',
+            `Sem fix — abriu: ${event.reason} | fechou: ${event.outcome}`
+          );
+        }
+      }
+    });
+
     return () => {
       beaconsSub.remove();
       syncLifecycleSub.remove();
       backgroundDetectionSub.remove();
       scanningSub.remove();
       errorSub.remove();
+      regionSub.remove();
+      activeScanSub.remove();
+      locationCaptureSub.remove();
     };
-  }, [refreshPermissions]);
+  }, [pushGeofenceEvent, refreshPermissions]);
 
   return (
     <SafeAreaView style={styles.safe}>
@@ -416,6 +573,88 @@ export default function App() {
             <Text style={styles.infoNote}>
               ✨ Sync automático: eventos em syncLifecycleListener
             </Text>
+          </View>
+        ) : null}
+
+        {isScanning ? (
+          <View style={styles.section}>
+            <View style={styles.geofenceHeader}>
+              <Text style={styles.sectionTitle}>Debug Geofence</Text>
+              {geofenceEvents.length > 0 ? (
+                <Pressable onPress={clearGeofenceLog}>
+                  <Text style={styles.clearLogText}>Limpar</Text>
+                </Pressable>
+              ) : null}
+            </View>
+
+            <InfoRow
+              label="Zona do beacon"
+              value={isInBeaconRegion ? 'DENTRO' : 'fora'}
+              valueColor={isInBeaconRegion ? '#4caf50' : '#9e9e9e'}
+            />
+            <InfoRow
+              label="Scan ativo"
+              value={isActiveScan ? 'LIGADO' : 'desligado'}
+              valueColor={isActiveScan ? '#4caf50' : '#9e9e9e'}
+            />
+            <InfoRow
+              label="Captura GPS"
+              value={isCapturingLocation ? 'EM ANDAMENTO…' : 'idle'}
+              valueColor={isCapturingLocation ? '#2196f3' : '#9e9e9e'}
+            />
+
+            <View style={styles.divider} />
+
+            <InfoRow label="Última abertura" value={lastCaptureOpenReason} />
+            <InfoRow label="Último fechamento" value={lastCaptureOutcome} />
+            {lastCapturedLocation ? (
+              <InfoRow
+                label="Última coord"
+                value={`${lastCapturedLocation.latitude.toFixed(5)}, ${lastCapturedLocation.longitude.toFixed(5)} ±${
+                  lastCapturedLocation.horizontalAccuracy !== undefined
+                    ? Math.round(lastCapturedLocation.horizontalAccuracy)
+                    : '?'
+                }m`}
+              />
+            ) : (
+              <InfoRow label="Última coord" value="—" />
+            )}
+            {lastCaptureCompletedAt ? (
+              <InfoRow
+                label="Concluído em"
+                value={`${formatTime(new Date(lastCaptureCompletedAt))}  (${formatAge(nowMs - lastCaptureCompletedAt)})`}
+              />
+            ) : null}
+
+            {geofenceEvents.length > 0 ? (
+              <>
+                <View style={styles.divider} />
+                <Text style={styles.eventLogTitle}>Eventos recentes</Text>
+                {geofenceEvents.slice(0, 10).map((event) => {
+                  const age = nowMs - event.timestamp;
+                  const color = geofenceEventColor(event.kind);
+                  return (
+                    <View key={event.id} style={styles.eventRow}>
+                      <View
+                        style={[styles.eventDot, { backgroundColor: color }]}
+                      />
+                      <View style={styles.eventBody}>
+                        <View style={styles.eventHeader}>
+                          <Text style={[styles.eventTitle, { color }]}>
+                            {geofenceEventTitle(event.kind)}
+                          </Text>
+                          <Text style={styles.eventTime}>
+                            {formatTime(new Date(event.timestamp))} ·{' '}
+                            {formatAge(age)}
+                          </Text>
+                        </View>
+                        <Text style={styles.eventDetail}>{event.detail}</Text>
+                      </View>
+                    </View>
+                  );
+                })}
+              </>
+            ) : null}
           </View>
         ) : null}
 
@@ -871,5 +1110,55 @@ const styles = StyleSheet.create({
   },
   errorText: {
     color: '#ff7675',
+  },
+  geofenceHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  clearLogText: {
+    color: '#bdbdbd',
+    fontSize: 12,
+  },
+  eventLogTitle: {
+    color: '#bdbdbd',
+    fontSize: 12,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  eventRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: 6,
+  },
+  eventDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginTop: 4,
+    marginRight: 8,
+  },
+  eventBody: {
+    flex: 1,
+  },
+  eventHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  eventTitle: {
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  eventTime: {
+    color: '#9e9e9e',
+    fontSize: 10,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  eventDetail: {
+    color: '#bdbdbd',
+    fontSize: 11,
+    marginTop: 2,
   },
 });

--- a/ios/BearoundReactSdkEventEmitter.swift
+++ b/ios/BearoundReactSdkEventEmitter.swift
@@ -21,6 +21,10 @@ public class BearoundReactSdkEventEmitter: RCTEventEmitter {
       "bearound:backgroundDetection",
       "bearound:scanning",
       "bearound:error",
+      // v2.4 — region + location capture lifecycle
+      "bearound:beaconRegion",
+      "bearound:activeScan",
+      "bearound:locationCapture",
     ]
   }
 

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -231,6 +231,60 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, BeAroundSDKD
     }
   }
 
+  // v2.4 — Beacon region + location capture lifecycle
+
+  public func didEnterBeaconRegion() {
+    DispatchQueue.main.async {
+      BearoundReactSdkEventEmitter.emit("bearound:beaconRegion", body: ["type": "enter"])
+    }
+  }
+
+  public func didExitBeaconRegion() {
+    DispatchQueue.main.async {
+      BearoundReactSdkEventEmitter.emit("bearound:beaconRegion", body: ["type": "exit"])
+    }
+  }
+
+  public func didChangeActiveScanState(isActive: Bool) {
+    DispatchQueue.main.async {
+      BearoundReactSdkEventEmitter.emit("bearound:activeScan", body: ["isActive": isActive])
+    }
+  }
+
+  public func didStartLocationCapture(reason: String) {
+    let payload: [String: Any] = [
+      "type": "started",
+      "reason": reason
+    ]
+    DispatchQueue.main.async {
+      BearoundReactSdkEventEmitter.emit("bearound:locationCapture", body: payload)
+    }
+  }
+
+  public func didCompleteLocationCapture(_ result: BeAroundLocationCapture) {
+    var payload: [String: Any] = [
+      "type": "completed",
+      "reason": result.reason,
+      "outcome": result.outcome,
+      "hasFix": result.hasFix,
+      "timestamp": Int(result.timestamp.timeIntervalSince1970 * 1000)
+    ]
+    if let loc = result.location {
+      payload["location"] = [
+        "latitude": loc.coordinate.latitude,
+        "longitude": loc.coordinate.longitude,
+        "horizontalAccuracy": loc.horizontalAccuracy,
+        "altitude": loc.altitude,
+        "speed": loc.speed,
+        "course": loc.course,
+        "timestamp": Int(loc.timestamp.timeIntervalSince1970 * 1000)
+      ]
+    }
+    DispatchQueue.main.async {
+      BearoundReactSdkEventEmitter.emit("bearound:locationCapture", body: payload)
+    }
+  }
+
   private func mapProximity(_ proximity: BeaconProximity) -> String {
     switch proximity {
     case .immediate:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,11 +75,52 @@ export type BearoundError = {
   message: string;
 };
 
+// v2.4 — region + location capture lifecycle
+
+export type BeaconRegionEvent = {
+  type: 'enter' | 'exit';
+};
+
+export type ActiveScanEvent = {
+  isActive: boolean;
+};
+
+export type CapturedLocation = {
+  latitude: number;
+  longitude: number;
+  horizontalAccuracy?: number;
+  altitude?: number;
+  speed?: number;
+  course?: number;
+  timestamp: number;
+};
+
+export type LocationCaptureStartedEvent = {
+  type: 'started';
+  reason: string;
+};
+
+export type LocationCaptureCompletedEvent = {
+  type: 'completed';
+  reason: string;
+  outcome: string;
+  hasFix: boolean;
+  timestamp: number;
+  location?: CapturedLocation;
+};
+
+export type LocationCaptureEvent =
+  | LocationCaptureStartedEvent
+  | LocationCaptureCompletedEvent;
+
 const EVENT_BEACONS = 'bearound:beacons';
 const EVENT_SYNC_LIFECYCLE = 'bearound:syncLifecycle';
 const EVENT_BACKGROUND_DETECTION = 'bearound:backgroundDetection';
 const EVENT_SCANNING = 'bearound:scanning';
 const EVENT_ERROR = 'bearound:error';
+const EVENT_BEACON_REGION = 'bearound:beaconRegion';
+const EVENT_ACTIVE_SCAN = 'bearound:activeScan';
+const EVENT_LOCATION_CAPTURE = 'bearound:locationCapture';
 
 const nativeModules = NativeModules as { [key: string]: NativeModule };
 const nativeModule: NativeModule =
@@ -187,6 +228,60 @@ const parseBackgroundDetectionEvent = (
   };
 };
 
+const parseBeaconRegionEvent = (event: unknown): BeaconRegionEvent => {
+  const payload = asMap(event);
+  const type = String(payload.type ?? '').toLowerCase();
+  return {
+    type: type === 'exit' ? 'exit' : 'enter',
+  };
+};
+
+const parseActiveScanEvent = (event: unknown): ActiveScanEvent => {
+  const payload = asMap(event);
+  return { isActive: Boolean(payload.isActive) };
+};
+
+const parseCapturedLocation = (
+  value: unknown
+): CapturedLocation | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const payload = value as Record<string, unknown>;
+  return {
+    latitude: asNumber(payload.latitude),
+    longitude: asNumber(payload.longitude),
+    horizontalAccuracy:
+      payload.horizontalAccuracy === undefined
+        ? undefined
+        : asNumber(payload.horizontalAccuracy),
+    altitude:
+      payload.altitude === undefined ? undefined : asNumber(payload.altitude),
+    speed: payload.speed === undefined ? undefined : asNumber(payload.speed),
+    course: payload.course === undefined ? undefined : asNumber(payload.course),
+    timestamp: asNumber(payload.timestamp),
+  };
+};
+
+const parseLocationCaptureEvent = (event: unknown): LocationCaptureEvent => {
+  const payload = asMap(event);
+  const type = String(payload.type ?? '').toLowerCase();
+  if (type === 'started') {
+    return {
+      type: 'started',
+      reason: String(payload.reason ?? ''),
+    };
+  }
+  return {
+    type: 'completed',
+    reason: String(payload.reason ?? ''),
+    outcome: String(payload.outcome ?? ''),
+    hasFix: Boolean(payload.hasFix),
+    timestamp: asNumber(payload.timestamp),
+    location: parseCapturedLocation(payload.location),
+  };
+};
+
 export async function configure(config: SdkConfig) {
   const {
     businessToken,
@@ -272,6 +367,47 @@ export function addErrorListener(
     }
     const payload = asMap(event);
     listener({ message: String(payload.message ?? 'Unknown error') });
+  });
+}
+
+/**
+ * Subscribe to beacon region enter/exit transitions.
+ *
+ * v2.4: fires when the device enters or exits the BLE proximity zone of a
+ * known beacon. Outside the region only the low-power kernel filter scan is
+ * active — active BLE scanning and GPS are off.
+ */
+export function addBeaconRegionListener(
+  listener: (event: BeaconRegionEvent) => void
+): EmitterSubscription {
+  return eventEmitter.addListener(EVENT_BEACON_REGION, (event) => {
+    listener(parseBeaconRegionEvent(event));
+  });
+}
+
+/**
+ * Subscribe to active-scan gating changes. Active scanning (BLE ranging +
+ * duty cycle) runs only while inside a beacon region.
+ */
+export function addActiveScanListener(
+  listener: (event: ActiveScanEvent) => void
+): EmitterSubscription {
+  return eventEmitter.addListener(EVENT_ACTIVE_SCAN, (event) => {
+    listener(parseActiveScanEvent(event));
+  });
+}
+
+/**
+ * Subscribe to beacon-triggered location capture lifecycle. Fires `started`
+ * when the SDK opens a one-shot GPS window because a beacon was detected,
+ * then `completed` with an outcome (and optional location fix) when the
+ * window closes.
+ */
+export function addLocationCaptureListener(
+  listener: (event: LocationCaptureEvent) => void
+): EmitterSubscription {
+  return eventEmitter.addListener(EVENT_LOCATION_CAPTURE, (event) => {
+    listener(parseLocationCaptureEvent(event));
   });
 }
 


### PR DESCRIPTION
## Summary

Bumps native SDKs to **v2.4.0** and surfaces the new region-gated GPS / active-scan lifecycle to JavaScript via 3 new event channels and 3 new listener helpers. All additive — existing API unchanged.

## Behavior inherited from native v2.4.0

GPS and active BLE scanning are **OFF by default**. They run only while iOS/Android reports the device is inside the beacon region. Outside the region, only kernel-level filter scan stays on (effectively zero battery cost). The RN bridge just forwards the lifecycle events upstream.

## New event channels

| Event name | Payload | Source |
|---|---|---|
| `bearound:beaconRegion` | `{ type: 'enter' \| 'exit' }` | iOS region monitoring / Android BLE scan rising/falling edge |
| `bearound:activeScan` | `{ isActive: boolean }` | Native SDK gates `bluetoothManager.startScanning` by region |
| `bearound:locationCapture` | `started`: `{ type, reason }` / `completed`: `{ type, reason, outcome, hasFix, timestamp, location? }` | Beacon-triggered GPS window |

## New TS exports

\`\`\`ts
import {
  addBeaconRegionListener,
  addActiveScanListener,
  addLocationCaptureListener,
  type BeaconRegionEvent,
  type ActiveScanEvent,
  type CapturedLocation,
  type LocationCaptureEvent,
} from '@bearound/react-native-sdk';

const sub = addLocationCaptureListener((event) => {
  if (event.type === 'completed' && event.hasFix && event.location) {
    console.log('fix:', event.location.latitude, event.location.longitude);
  }
});
\`\`\`

## Files touched

| Area | Files |
|---|---|
| iOS bridge | \`ios/BearoundReactSdkEventEmitter.swift\`, \`ios/RNBearoundBridge.swift\` |
| Android bridge | \`android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt\` |
| TS API | \`src/index.tsx\` (parsers + types + listener helpers) |
| Example app | \`example/src/App.tsx\` (new Debug Geofence section with 1Hz live ages) |
| Pins | \`package.json\` 2.3.7→2.4.0, \`BearoundReactSdk.podspec\` ~> 2.4.0, \`android/build.gradle\` 2.4.0 |
| Cleanup | Removed \`example/ios/Podfile.lock\` per PUBLISH.md |
| Notes | \`CHANGELOG.md\` 2.4.0 section |

## Trade-offs accepted (mirrors native v2.4.0 PRs)

- Apps that previously assumed continuous location updates outside beacon zones now receive no location until a beacon is detected.
- Cold-start GPS in background can miss the 15s capture window; subsequent windows benefit from cached fixes (<10min stale threshold native-side).
- 3 additional native events at runtime — `addListener`/`removeListeners` impl in Android module already handles this.

## Test plan

- [x] \`yarn typecheck\` → 0 errors
- [x] \`yarn lint\` → 0 errors (after \`--fix\` ran prettier auto-formats)
- [ ] iOS: build example app — confirm Swift compiles against \`BearoundSDK ~> 2.4.0\` once that pod is fetched
- [ ] Android: build example app — confirm Kotlin compiles against \`bearound-android-sdk:2.4.0\` once that artifact is on JitPack
- [ ] On-device: launch example app, scan, approach beacon — Debug Geofence section shows ENTROU NA ZONA → SCAN LIGADO → GPS DISPARADO → FIX OK
- [ ] On-device: walk away — region exit transition fires, scan goes back to PAUSADO

## Notes

- Both native dependencies must be published (iOS 2.4.0 to CocoaPods, Android 2.4.0 to JitPack) before this RN package can be installed and tested end-to-end. PR \`Bearound/bearound-ios-sdk#29\` and \`Bearound/bearound-android-sdk#40\` cover the native sides.
