### PR TITLE
chore(rn): auditoria DX + bump 3.4.5 (permissões, reliability, PermissionResult)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -233,7 +233,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate]
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout
@@ -248,6 +248,20 @@ jobs:
           node-version: '22'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
+
+      # Guard: the pushed tag (vX.Y.Z) must match package.json version, so an
+      # npm publish can never ship under a version the git tag doesn't claim.
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          echo "Tag version:    $TAG"
+          echo "package.json:   $PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match package.json version $PKG. Bump package.json (and the CHANGELOG) before tagging."
+            exit 1
+          fi
+          echo "✅ Tag matches package.json ($PKG)"
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -266,3 +280,15 @@ jobs:
         run: |
           echo "Publishing package..."
           npm publish --access public --provenance
+
+      # Create a GitHub Release for the tag so the changelog is discoverable and
+      # the npm publish has a matching release artifact.
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.4.2"
+  s.dependency "BearoundSDK", "3.4.5"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5] - 2026-07-02
+
+### Fixed
+
+- **Android: FGS `connectedDevice` crash-loop (via native SDK 3.4.5).** Bumped the Android native SDK `3.4.2 → 3.4.5`, which fixes the foreground-service `connectedDevice` `SecurityException` crash-loop on Android 14+ when the user denies "Nearby devices". The RN wrapper exposes `enableForegroundScanning`, so it inherited this crash until now. iOS `BearoundSDK` bumped `3.4.2 → 3.4.5` in lockstep.
+- **Permission flow no longer sabotages itself on Android 12+.** `requestForegroundPermissions()` now gates by API level: on Android 12+ it requests `BLUETOOTH_SCAN` (+ `BLUETOOTH_CONNECT`, and `POST_NOTIFICATIONS` on 13+) and **does not** request location — the scan is unlocked by `BLUETOOTH_SCAN` (`neverForLocation`), so asking for location was pointless and risked a Play review flag. On Android ≤ 11 it still requests fine location (coarse fallback).
+- **`ensurePermissions()` no longer requests background location by default** and **never opens app Settings automatically.** Background location is not a scan requirement and, undeclared, resolves to `NEVER_ASK_AGAIN`; request it only via the explicit `{ askBackground: true }` opt-in. `requestBackgroundLocation()` returns the denial state instead of calling `Linking.openSettings()` — routing to Settings is now the host app's decision.
+- **iOS `PermissionResult` reports real values.** `notifications` now comes from a real `UNUserNotificationCenter` check (was hardcoded `true`) and `backgroundLocation` is `true` only for `authorizedAlways` (When-In-Use no longer reported as background-capable). Android answers `checkNotificationPermission` via `NotificationManagerCompat`.
+
+### Added
+
+- **Background reliability helpers (Android-only; native SDK 3.4.5), the Xiaomi/Huawei kill mitigation:** `isIgnoringBatteryOptimizations()`, `openBatteryOptimizationSettings()`, `isAutostartManageable()`, `openManufacturerAutostartSettings()`. iOS has no user-facing equivalent — `isIgnoringBatteryOptimizations()` resolves `true` and the others resolve `false`.
+
 ## [3.4.2] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -731,12 +731,40 @@ bluetoothStateSub.remove();
 
 ## Troubleshooting
 
-**SDK doesn't start or detect beacons**
+**No beacons detected (any platform)**
 
-* Check **Location**/**Bluetooth** permissions (and Background on Android 10+).
-* Test with a **physical beacon** (or app like nRF Connect).
-* **iOS**: Use `ensurePermissions()` before calling `startScanning()` and keep Info.plist configured.
-* **Android**: Use `ensurePermissions()` before calling `startScanning()`.
+* Test with a **real Bearound beacon**. The SDK scans for Bearound's proprietary BLE advertisement (service data `0xBEAD`) — a **generic iBeacon, or a phone simulating one with nRF Connect, is NOT detected** by design.
+* Call `configure()` before `startScanning()` — `startScanning()` without a prior `configure()` resolves without error but detects nothing. Check with `isConfigured()`.
+* Verify the business token. An invalid token fails **silently** in the current version: beacons still appear locally, but every sync fails — watch `addSyncLifecycleListener` for `completed` events with `success: false`.
+* Check Bluetooth: `getBluetoothState()` should resolve `'poweredOn'` (`'unauthorized'` on iOS means the Bluetooth permission was denied).
+
+**Android 12+ (API 31+): permissions**
+
+* `BLUETOOTH_SCAN` ("Nearby devices") is the **only** permission that unlocks scanning. It is declared with `neverForLocation`, so **granting Location does NOT unlock the BLE scan** — a device with Location granted but Nearby devices denied detects nothing.
+* `POST_NOTIFICATIONS` (Android 13+) is only needed for the persistent notification of `enableForegroundScanning()` to be visible.
+* `BLUETOOTH_CONNECT` and background location are **not** required for scanning.
+
+**Android ≤ 11 (API ≤ 30): permissions**
+
+* Fine (or coarse) **location** is what unlocks BLE scan results (Android platform requirement on these versions). The legacy `BLUETOOTH`/`BLUETOOTH_ADMIN` permissions arrive via manifest merge.
+
+**Android: detection stops in background or after swipe-away**
+
+* The default (opportunistic) mode is throttled by the OS and killed outright by aggressive OEMs (Xiaomi/Huawei/Samsung and others). For reliable background detection, use `enableForegroundScanning()` ([Mode 2](#mode-2--foreground-service-connecteddevice)) and ask the user to exempt the app from battery optimization / enable autostart in the OEM settings.
+* Remember the Play cost of Mode 2: the `connectedDevice` foreground service requires a Play Console declaration **and a demonstration video** during review — see [Scan modes](#scan-modes-android).
+
+**Android: scan throttled after rapid start/stop**
+
+* Android silently throttles apps that start/stop BLE scans too frequently (more than ~5 starts in 30 s). Avoid `startScanning()`/`stopScanning()` loops; prefer a stable lifecycle.
+
+**iOS: nothing detected in background / app never wakes**
+
+* **Physical device only** — BLE does not work on the iOS simulator.
+* Grant **Always** location: waking a terminated app on beacon entry relies on CoreLocation region monitoring, and Always is required. Check with `getAuthorizationStatus()` (must be `'always'`, not `'whenInUse'`).
+* Enable **Background App Refresh** (Settings → General → Background App Refresh, and per-app): without it the SDK's BGTasks (sync/processing) never get execution time.
+* The **silent-push wake vector** — the only mechanism that resurrects a fully terminated app — needs the Push Notifications capability and a delivered APNs token; see [iOS Background Integration](#ios-background-integration-required). If you use Firebase Messaging, forward the raw APNs token yourself via `setPushToken` (the swizzle won't fire).
+* Force-quit (swipe up in the app switcher) suspends the Bluetooth eye until the app is relaunched — by region entry (CoreLocation) or silent push.
+* Complete the AppDelegate + Info.plist wiring (background modes, BGTask identifiers) — see [iOS Background Integration](#ios-background-integration-required).
 
 **iOS: compilation error involving headers/Codegen**
 
@@ -744,18 +772,17 @@ bluetoothStateSub.remove();
 * Clean Derived Data in Xcode and recompile.
 * If using `use_frameworks!`, prefer `:linkage => :static`.
 
-**Android: crash on restart**
+---
 
-* Avoid calling `startScanning()` repeatedly without `stopScanning()`. Some BLE scanners don't allow frequent restarts.
+## Migrating from 2.x
 
-**Android permissions (API 31+)**
+Version 3.x of this package tracks the native SDKs across their 3.0.0 major. If you are coming from `@bearound/react-native-sdk` 2.x:
 
-* Ensure `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` at runtime. Use `ensurePermissions`.
-
-**Missing background location permission**
-
-* **Android 10+**: Background location requires separate permission request after foreground location.
-* **Android 12+**: Background location can be requested independently of fine location.
+* **`locationCapture` API removed** — native 3.x dropped beacon-triggered GPS capture. Remove `addLocationCaptureListener` and the `CapturedLocation`/`LocationCapture*` types; there is no replacement (the SDK no longer captures GPS coordinates).
+* **`BeaconMetadata` semantics changed**: `batteryLevel` is now **millivolts** (e.g. `3269`), not a 0–100 percentage; `firmwareVersion` is now an integer encoded as a string (e.g. `"1"`), not a semver (`"2.1.0"`). Update any UI/analytics that parsed these.
+* **Default `scanPrecision` is now `HIGH`** (was `MEDIUM`). Pass `scanPrecision: ScanPrecision.MEDIUM` explicitly to keep the 2.x duty cycle.
+* Coming from **≤ 2.1.0**: `enableBluetoothScanning`/`enablePeriodicScanning` config flags were removed (always-on) and `addSyncStatusListener` was replaced by `addSyncLifecycleListener`.
+* Everything else is additive — two-eyes listeners, persisted log, foreground-service APIs, diagnostics getters, `setPushToken` (3.4.1+). Full details per release in [CHANGELOG.md](./CHANGELOG.md); cross-platform behavior in [EVENT-PARITY.md](./EVENT-PARITY.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🐻 Bearound React Native SDK
 
 Official SDK to integrate **Bearound's** secure BLE beacon detection into **React Native** apps (Android and iOS).
-Aligned with Bearound native SDKs **3.3.1**.
+Aligned with Bearound native SDKs **3.4.2** (exact pins live in `android/build.gradle` and `BearoundReactSdk.podspec`, kept in lockstep by `scripts/check-native-versions.mjs`).
 
 > ✅ Compatible with **New Architecture** (TurboModules) and also compatible with classic architecture.
 
@@ -14,6 +14,7 @@ Aligned with Bearound native SDKs **3.3.1**.
 * [Permission Configuration](#permission-configuration)
   * [Android – Manifest](#android--manifest)
   * [iOS – Info.plist and Background Modes](#ios--infoplist-and-background-modes)
+* [Scan modes (Android)](#scan-modes-android)
 * [iOS Background Integration (required)](#ios-background-integration-required)
 * [Quick Start](#quick-start)
 * [API](#api)
@@ -22,14 +23,17 @@ Aligned with Bearound native SDKs **3.3.1**.
   * [Events](#events)
 * [Best Practices](#best-practices)
 * [Troubleshooting](#troubleshooting)
+* [Migrating from 2.x](#migrating-from-2x)
 * [License](#license)
+
+> Cross-platform behavior of every event and getter (including iOS-only / Android-only gaps) is documented in [EVENT-PARITY.md](./EVENT-PARITY.md).
 
 ---
 
 ## Requirements
 
 * **React Native** ≥ 0.73
-* **Android**: minSdk **21+** (BLE), Android 12+ requires runtime BLE permissions
+* **Android**: minSdk **24+** (the library builds with `minSdkVersion 24`); Android 12+ requires the `BLUETOOTH_SCAN` runtime permission ("Nearby devices")
 * **iOS**: iOS **13+** (recommended 15+), Bluetooth and Location enabled
 
 > **Important:** The SDK **does not** work on iOS simulator for BLE (use physical device).
@@ -57,7 +61,7 @@ cd ios
 pod install
 ```
 
-> The package already includes the native iOS framework as **vendored xcframework** in the Podspec. If your `Podfile` uses `use_frameworks!`, prefer **static**:
+> The Podspec declares a **CocoaPods dependency** on the native `BearoundSDK` pod (exact version pin — see `BearoundReactSdk.podspec`), resolved automatically by `pod install`. If your `Podfile` uses `use_frameworks!`, prefer **static**:
 >
 > ```ruby
 > use_frameworks! :linkage => :static

--- a/README.md
+++ b/README.md
@@ -364,36 +364,55 @@ This is a **native-level escape hatch** — by design it is not part of the JS A
 
 ## Quick Start
 
+Two rules the snippet below follows — both come from how the SDK actually works:
+
+1. **`configure()` runs on mount** (in a `useEffect`), **not** behind a button. The SDK's push swizzle (automatic APNs token capture + silent-push handling) only installs once `configure()` runs in the process — see [§4 of iOS Background Integration](#4-call-configure-on-app-mount).
+2. **The Android permission gate depends on the OS version.** On Android 12+ the **only** permission that unlocks scanning is `BLUETOOTH_SCAN` ("Nearby devices") — location does **not** unlock BLE scan there (the SDK declares `neverForLocation`). On Android ≤ 11 it's the opposite: location is what unlocks scanning. Do **not** gate on `btConnect`/`backgroundLocation` — the SDK doesn't need them to scan, and on 12+ they can never all be granted (the location permissions are declared with `maxSdkVersion="30"`).
+
 ```tsx
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Alert, Button, View, Platform } from 'react-native';
 import * as BeAround from '@bearound/react-native-sdk';
 import { ensurePermissions } from '@bearound/react-native-sdk';
 
 export default function App() {
-  const start = async () => {
-    // Request permissions (Android + iOS)
-    const status = await ensurePermissions({ askBackground: true });
-    const ok =
-      Platform.OS === 'android'
-        ? status.fineLocation &&
-          status.btScan &&
-          status.btConnect &&
-          status.notifications &&
-          status.backgroundLocation
-        : status.fineLocation;
-
-    if (!ok) {
-      Alert.alert('Permissions', 'Grant required permissions to start.');
-      return;
-    }
-
-    await BeAround.configure({
+  useEffect(() => {
+    // On mount — installs the push swizzle in every process, including
+    // background relaunches where the user never taps anything.
+    BeAround.configure({
       businessToken: 'your-business-token',
       scanPrecision: BeAround.ScanPrecision.HIGH,
       maxQueuedPayloads: BeAround.MaxQueuedPayloads.MEDIUM,
     });
+  }, []);
+
+  const start = async () => {
+    // askBackground: false — background location is NOT needed for scanning.
+    // Only pass true if your app declares ACCESS_BACKGROUND_LOCATION itself
+    // (the SDK doesn't); otherwise the request is auto-denied and the helper
+    // bounces the user to Settings.
+    const status = await ensurePermissions({ askBackground: false });
+
+    const ok =
+      Platform.OS === 'android'
+        ? Number(Platform.Version) >= 31
+          ? status.btScan // Android 12+: BLUETOOTH_SCAN is the only scan gate
+          : status.fineLocation // Android ≤ 11: location unlocks BLE scan
+        : true; // iOS: either eye works (Location OR Bluetooth) — don't hard-block
+
+    if (!ok) {
+      Alert.alert(
+        'Permissions',
+        Number(Platform.Version) >= 31
+          ? 'Allow "Nearby devices" to detect beacons.'
+          : 'Allow Location to detect beacons.'
+      );
+      return;
+    }
+
     await BeAround.startScanning();
+    // Android 13+: if you also call enableForegroundScanning(), check
+    // status.notifications so the persistent notification is visible.
     Alert.alert('Bearound', 'SDK started successfully');
   };
 

--- a/README.md
+++ b/README.md
@@ -543,6 +543,18 @@ isScanning(): Promise<boolean>;
 setUserProperties(properties: UserProperties): Promise<void>;
 clearUserProperties(): Promise<void>;
 
+// Push token — forwards the token to the native SDK, which associates it with
+// the device and sends it on the next sync (re-sent only when it changes or
+// after the native heartbeat window).
+// - Android: pass the FCM token. The native SDK also auto-collects it when
+//   Firebase is present; this call is the explicit fallback.
+// - iOS: the SDK auto-captures the APNs token via AppDelegate swizzling. Call
+//   this only when swizzling doesn't fire (e.g. Firebase Messaging swizzles
+//   first, or BearoundAppDelegateProxyEnabled = NO) — and pass the RAW APNs
+//   device token (hex), which is what the backend expects, not the FCM token.
+//   See "Using Firebase Messaging / disabled swizzling?" above.
+setPushToken(token: string): Promise<void>;
+
 // Event listeners
 addBeaconsListener(listener: (beacons: Beacon[]) => void): EmitterSubscription;
 addSyncLifecycleListener(listener: (event: SyncLifecycleEvent) => void): EmitterSubscription;
@@ -611,6 +623,36 @@ requestForegroundPermissions(): Promise<{
 requestBackgroundLocation(): Promise<boolean>;
 ```
 
+> **`PermissionResult` semantics on iOS:** the iOS bridge checks a single thing —
+> **location authorization** (`authorizedAlways` **or** `authorizedWhenInUse`).
+> `fineLocation`, `btScan`, `btConnect` and `backgroundLocation` all mirror that one
+> location boolean, and `notifications` is hardcoded `true` (never checked). In
+> particular:
+>
+> * `btScan`/`btConnect` do **not** reflect the Bluetooth permission on iOS — use
+>   [`getBluetoothState()`](#functions) instead (`'unauthorized'` means Bluetooth
+>   permission was denied).
+> * `backgroundLocation: true` does **not** mean "Always" was granted — it is `true`
+>   with only When-In-Use. Use `getAuthorizationStatus()` to distinguish `'always'`
+>   from `'whenInUse'` (terminated-app wake-up requires **Always**).
+> * On iOS, `ensurePermissions`/`requestForegroundPermissions` trigger the system
+>   location prompt (requesting Always) only while the status is `notDetermined`;
+>   once denied they resolve `false` without prompting.
+>
+> On Android each field reflects the real status of its permission
+> (`ACCESS_FINE_LOCATION`/`ACCESS_COARSE_LOCATION`, `BLUETOOTH_SCAN`,
+> `BLUETOOTH_CONNECT`, `POST_NOTIFICATIONS`, `ACCESS_BACKGROUND_LOCATION`), but note
+> the SDK manifest only declares the location permissions up to API 30 and does not
+> declare `ACCESS_BACKGROUND_LOCATION` — so on Android 12+ `fineLocation` and
+> `backgroundLocation` stay `false` unless your app declares them itself. Gate
+> scanning as shown in [Quick Start](#quick-start), not on "all fields true".
+
+> **`getBluetoothState()` on iOS — side effect:** the first call lazily creates the
+> `CBCentralManager`, which triggers the system **Bluetooth permission prompt** if
+> not yet determined. It is also what arms `addBluetoothStateListener` on iOS — the
+> listener only starts emitting after the first `getBluetoothState()` call in the
+> process (on Android it emits on adapter changes without any prior call).
+
 ### Events
 
 Available listeners:
@@ -624,7 +666,7 @@ Available listeners:
 * `addActiveScanListener` — fires when active-scan gating changes (BLE ranging + duty cycle run only while inside a beacon region).
 * `addBluetoothZoneListener` — **iOS-only**: fires on Bluetooth-zone enter/exit (the "Bluetooth eye", backed by CBCentralManager, independent of CoreLocation). On Android the listener registers but never fires.
 * `addBluetoothScanModeListener` — **iOS-only**: fires when the BLE scanner duty-cycle mode changes (`idle` ↔ `active`, with `nextIdleScanAt` when idle). On Android the listener registers but never fires.
-* `addBluetoothStateListener` — fires on Bluetooth adapter state changes (`poweredOn`/`poweredOff`/`unauthorized`/...) on **both platforms** — use it to gate the Bluetooth eye independently of location.
+* `addBluetoothStateListener` — fires on Bluetooth adapter state changes (`poweredOn`/`poweredOff`/`unauthorized`/...) on **both platforms** — use it to gate the Bluetooth eye independently of location. **iOS:** it only starts emitting after the first `getBluetoothState()` call in the process (which creates the underlying `CBCentralManager` and may show the Bluetooth permission prompt); call it once on mount if you rely on this listener.
 
 ```ts
 import {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,6 +76,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   // Exact pin, kept in lockstep with the iOS podspec dep (same native release).
-  // 3.3.x carries the configure(technology:) param.
-  implementation 'com.github.Bearound:bearound-android-sdk:3.4.2'
+  // 3.4.5 fixes the FGS connectedDevice crash-loop and adds the battery-opt/OEM
+  // autostart reliability helpers exposed by the RN bridge.
+  implementation 'com.github.Bearound:bearound-android-sdk:3.4.5'
 }

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -200,6 +201,13 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
 
   override fun requestPermissions(promise: Promise) {
     promise.resolve(true)
+  }
+
+  // Real notification status (channel/permission), used by the JS PermissionResult
+  // on iOS; on Android permissions.ts checks POST_NOTIFICATIONS directly, but the
+  // method answers honestly here too.
+  override fun checkNotificationPermission(promise: Promise) {
+    promise.resolve(NotificationManagerCompat.from(ctx).areNotificationsEnabled())
   }
 
   // Diagnostic / state getters (parity with native public API).

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -312,6 +312,25 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     promise.resolve(null)
   }
 
+  // Background reliability (Android-only) — the OEM/Doze kill mitigation from the
+  // native SDK 3.4.5. Delegates straight to the native helpers; iOS is a no-op.
+
+  override fun isIgnoringBatteryOptimizations(promise: Promise) {
+    promise.resolve(sdk.isIgnoringBatteryOptimizations())
+  }
+
+  override fun openBatteryOptimizationSettings(promise: Promise) {
+    promise.resolve(sdk.openBatteryOptimizationSettings())
+  }
+
+  override fun isAutostartManageable(promise: Promise) {
+    promise.resolve(sdk.isAutostartManageable())
+  }
+
+  override fun openManufacturerAutostartSettings(promise: Promise) {
+    promise.resolve(sdk.openManufacturerAutostartSettings())
+  }
+
   // Host app's own name (android:label), already localized by Android per device
   // locale. No dependency, no Info.plist/gradle reading needed.
   private fun appLabel(): String =

--- a/example/README.md
+++ b/example/README.md
@@ -1,97 +1,72 @@
-This is a new [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
+# BeAroundScan — example app
 
-# Getting Started
+Debug/demo app for `@bearound/react-native-sdk`. It mirrors the iOS native demo app: it **auto-configures and starts scanning on launch** (no button press needed) and exposes the SDK's full event surface in a dark-themed debug UI.
 
-> **Note**: Make sure you have completed the [Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) guide before proceeding.
+> Beacons: the SDK only detects **Bearound's proprietary beacons** (BLE service data `0xBEAD`). A generic iBeacon or a phone simulating one (nRF Connect) will not show up — you need a real Bearound beacon nearby.
 
-## Step 1: Start Metro
+## Business token
 
-First, you will need to run **Metro**, the JavaScript build tool for React Native.
+The token is hardcoded in [`src/App.tsx`](./src/App.tsx) (`configureSdk`, the `businessToken` field):
 
-To start the Metro dev server, run the following command from the root of your React Native project:
+```ts
+businessToken: 'ee2ec9c46d2b2ad99bddcdd0afe224e6',
+```
+
+This is a **public test token, published on purpose** so anyone can run the example against the Bearound ingest. To see devices/detections in *your* Control Hub, replace it with your own business token.
+
+## Running
+
+Install dependencies from the **repo root** (Yarn workspaces):
 
 ```sh
-# Using npm
-npm start
+yarn
+```
 
-# OR using Yarn
+Then, in this folder:
+
+```sh
+# Start Metro
 yarn start
-```
 
-## Step 2: Build and run your app
-
-With Metro running, open a new terminal window/pane from the root of your React Native project, and use one of the following commands to build and run your Android or iOS app:
-
-### Android
-
-```sh
-# Using npm
-npm run android
-
-# OR using Yarn
+# Android (device or emulator — detection needs a real device with BLE)
 yarn android
-```
 
-### iOS
-
-For iOS, remember to install CocoaPods dependencies (this only needs to be run on first clone or after updating native deps).
-
-The first time you create a new project, run the Ruby bundler to install CocoaPods itself:
-
-```sh
-bundle install
-```
-
-Then, and every time you update your native dependencies, run:
-
-```sh
-bundle exec pod install
-```
-
-For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
-
-```sh
-# Using npm
-npm run ios
-
-# OR using Yarn
+# iOS (physical device only for BLE; first time: install pods)
+bundle install               # once
+bundle exec pod install      # in example/ios, after native dep changes
 yarn ios
 ```
 
-If everything is set up correctly, you should see your new app running in the Android Emulator, iOS Simulator, or your connected device.
+## What the UI demonstrates
 
-This is one way to run your app — you can also build it directly from Android Studio or Xcode.
+| UI element | SDK API exercised |
+|---|---|
+| **Permissões** card | `checkPermissions()` / `ensurePermissions()`, `getBluetoothState()` + `addBluetoothStateListener` — shows the "two eyes" model: scanning works with Location **or** Bluetooth (`anyOf`), so it only warns when **neither** is available |
+| **Informações do Scan / Sync** cards | `addSyncLifecycleListener` (started/completed, duration, success/failure), current `ScanPrecision` and `MaxQueuedPayloads` |
+| **Debug Geofence** card | `addBeaconRegionListener` (region enter/exit), `addActiveScanListener` (ranging gating), rolling event log with live ages |
+| **👁 👁 Dois Olhos** modal | Location eye vs Bluetooth eye side by side: `addBluetoothZoneListener`, `addBluetoothScanModeListener` (iOS-only; on Android the Bluetooth eye card shows as unavailable), per-eye beacon counts from `discoverySources` |
+| **📋 Log** modal | `getPersistedLog()` / `clearPersistedLog()` — on iOS this is the **native persisted log** (survives restarts, records background/terminated wakes); on Android the SDK exposes no log API, so the modal shows a JS-side in-memory log only |
+| **⚙︎ Settings** modal | Re-`configure()` at runtime with a different `ScanPrecision` / `MaxQueuedPayloads`; shows `getSdkVersion()` |
+| Beacon cards | `addBeaconsListener` — RSSI, proximity, accuracy, `metadata` (battery in mV, temperature, movements, firmware), sync status (`alreadySynced`/`syncedAt`), iOS `discoverySources` badges, Android `rssiSamples`/`isStale` |
+| Start/stop buttons | `configure()` → `startScanning()` / `stopScanning()`, plus `enableForegroundScanning()` on Android (see below) |
 
-## Step 3: Modify your app
+On Android, `startScan` also calls **`enableForegroundScanning()`** — the foreground-service mode ([Mode 2 in the root README](../README.md#scan-modes-android)) — so background detection survives swipe-away. The persistent notification shows just the app name.
 
-Now that you have successfully run the app, let's make changes!
+## Testing background behavior (physical device)
 
-Open `App.tsx` in your text editor of choice and make some changes. When you save, your app will automatically update and reflect these changes — this is powered by [Fast Refresh](https://reactnative.dev/docs/fast-refresh).
+### Android
 
-When you want to forcefully reload, for example to reset the state of your app, you can perform a full reload:
+1. Start the scan, then background the app (home button) — detection keeps running via the foreground service (persistent notification visible; on Android 13+ grant the notifications permission to see it).
+2. Swipe the app away from recents — the service keeps the process alive; beacon events continue (watch the notification / Control Hub).
+3. On aggressive OEMs (Xiaomi/Huawei/Samsung), also disable battery optimization for the app, or the OS may still kill it.
 
-- **Android**: Press the <kbd>R</kbd> key twice or select **"Reload"** from the **Dev Menu**, accessed via <kbd>Ctrl</kbd> + <kbd>M</kbd> (Windows/Linux) or <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> (macOS).
-- **iOS**: Press <kbd>R</kbd> in iOS Simulator.
+### iOS
 
-## Congratulations! :tada:
+1. Use a **physical device** (no BLE on simulator), grant **Always** location when prompted, and enable **Background App Refresh** for the app.
+2. Background the app near a beacon → watch the **📋 Log** modal after reopening: entries tagged `background`/`backgroundLocked` were written natively while the UI was away.
+3. Terminated test: background the app, wait for iOS to evict it (or reboot the device — do **not** force-quit from the app switcher, that's a different, user-intent state), then walk into beacon range. CoreLocation region entry relaunches the app; the log shows entries tagged `terminated`.
+4. Silent push (the only wake vector after a force-quit) requires the Push Notifications capability and an APNs token — see [iOS Background Integration in the root README](../README.md#ios-background-integration-required). The example's `AppDelegate.swift` + `Info.plist` already carry the full wiring (delegate re-set, `registerBackgroundTasks()`, the five `UIBackgroundModes`, both `BGTaskSchedulerPermittedIdentifiers`) — copy them into your app as-is.
 
-You've successfully run and modified your React Native App. :partying_face:
+## Troubleshooting
 
-### Now what?
-
-- If you want to add this new React Native code to an existing application, check out the [Integration guide](https://reactnative.dev/docs/integration-with-existing-apps).
-- If you're curious to learn more about React Native, check out the [docs](https://reactnative.dev/docs/getting-started).
-
-# Troubleshooting
-
-If you're having issues getting the above steps to work, see the [Troubleshooting](https://reactnative.dev/docs/troubleshooting) page.
-
-# Learn More
-
-To learn more about React Native, take a look at the following resources:
-
-- [React Native Website](https://reactnative.dev) - learn more about React Native.
-- [Getting Started](https://reactnative.dev/docs/environment-setup) - an **overview** of React Native and how setup your environment.
-- [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
-- [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
-- [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+See the [root README's Troubleshooting](../README.md#troubleshooting). For generic React Native environment issues (Metro, emulators, CocoaPods), see the [React Native docs](https://reactnative.dev/docs/environment-setup).

--- a/ios/BearoundReactSdk.mm
+++ b/ios/BearoundReactSdk.mm
@@ -192,4 +192,28 @@ maxQueuedPayloads:(double)maxQueuedPayloads
   resolve(nil);
 }
 
+- (void)isIgnoringBatteryOptimizations:(RCTPromiseResolveBlock)resolve
+                                reject:(RCTPromiseRejectBlock)reject
+{
+  resolve(@([[RNBearoundBridge shared] isIgnoringBatteryOptimizations]));
+}
+
+- (void)openBatteryOptimizationSettings:(RCTPromiseResolveBlock)resolve
+                                 reject:(RCTPromiseRejectBlock)reject
+{
+  resolve(@([[RNBearoundBridge shared] openBatteryOptimizationSettings]));
+}
+
+- (void)isAutostartManageable:(RCTPromiseResolveBlock)resolve
+                       reject:(RCTPromiseRejectBlock)reject
+{
+  resolve(@([[RNBearoundBridge shared] isAutostartManageable]));
+}
+
+- (void)openManufacturerAutostartSettings:(RCTPromiseResolveBlock)resolve
+                                   reject:(RCTPromiseRejectBlock)reject
+{
+  resolve(@([[RNBearoundBridge shared] openManufacturerAutostartSettings]));
+}
+
 @end

--- a/ios/BearoundReactSdk.mm
+++ b/ios/BearoundReactSdk.mm
@@ -86,6 +86,14 @@ maxQueuedPayloads:(double)maxQueuedPayloads
   }];
 }
 
+- (void)checkNotificationPermission:(RCTPromiseResolveBlock)resolve
+                             reject:(RCTPromiseRejectBlock)reject
+{
+  [[RNBearoundBridge shared] checkNotificationPermission:^(BOOL granted) {
+    resolve(@(granted));
+  }];
+}
+
 - (void)getSdkVersion:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject
 {

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreLocation
 import CoreBluetooth
+import UserNotifications
 import BearoundSDK
 
 @objcMembers
@@ -227,6 +228,18 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
   public func checkPermissions() -> Bool {
     let status = currentAuthorizationStatus()
     return status == .authorizedAlways || status == .authorizedWhenInUse
+  }
+
+  // Real notification-permission check (UNUserNotificationCenter). Backs the
+  // `notifications` field of the JS PermissionResult — previously hardcoded true.
+  public func checkNotificationPermission(_ completion: @escaping (Bool) -> Void) {
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+      let granted =
+        settings.authorizationStatus == .authorized
+        || settings.authorizationStatus == .provisional
+        || settings.authorizationStatus == .ephemeral
+      completion(granted)
+    }
   }
 
   public func requestPermissions(_ completion: @escaping (Bool) -> Void) {

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -170,6 +170,27 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
 
   public func setForegroundNotificationContent(_ content: NSDictionary) {}
 
+  // Background reliability (Android-only; no-op on iOS). iOS has no user-facing
+  // battery-optimization / autostart exemption like Android's Doze / OEM killers.
+  // Report "already ignoring optimizations" so hosts don't prompt, and false for
+  // the Android-only open-settings / autostart methods.
+
+  public func isIgnoringBatteryOptimizations() -> Bool {
+    return true
+  }
+
+  public func openBatteryOptimizationSettings() -> Bool {
+    return false
+  }
+
+  public func isAutostartManageable() -> Bool {
+    return false
+  }
+
+  public func openManufacturerAutostartSettings() -> Bool {
+    return false
+  }
+
   public func startScanning() {
     DispatchQueue.main.async {
       self.sdk.delegate = self

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.4.2",
+  "version": "3.4.5",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -52,6 +52,14 @@ export interface Spec extends TurboModule {
   isForegroundScanningEnabled(): Promise<boolean>;
   setForegroundNotificationContent(content: Object): Promise<void>;
 
+  // Background reliability (Android-only; the OEM/Doze kill mitigation from
+  // native SDK 3.4.5). iOS has no user-facing equivalent — the "open" methods
+  // resolve false and isIgnoringBatteryOptimizations resolves true.
+  isIgnoringBatteryOptimizations(): Promise<boolean>;
+  openBatteryOptimizationSettings(): Promise<boolean>;
+  isAutostartManageable(): Promise<boolean>;
+  openManufacturerAutostartSettings(): Promise<boolean>;
+
   addListener(eventName: string): void;
   removeListeners(count: number): void;
 }

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -22,6 +22,11 @@ export interface Spec extends TurboModule {
   checkPermissions(): Promise<boolean>;
   requestPermissions(): Promise<boolean>;
 
+  // Real notification-permission status. iOS: UNUserNotificationCenter
+  // getNotificationSettings (authorized/provisional/ephemeral). Android:
+  // NotificationManagerCompat.areNotificationsEnabled().
+  checkNotificationPermission(): Promise<boolean>;
+
   // Diagnostic / state getters (parity with native public API).
   // Platform-divergent values resolve to a neutral default on the platform
   // that lacks the underlying native API (see index.tsx docs).

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -334,6 +334,25 @@ describe('Foreground scanning (Android-only)', () => {
   });
 });
 
+describe('Background reliability (Android-only)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMocks();
+  });
+
+  it.each([
+    ['isIgnoringBatteryOptimizations', true],
+    ['openBatteryOptimizationSettings', true],
+    ['isAutostartManageable', false],
+    ['openManufacturerAutostartSettings', false],
+  ] as const)('%s delegates to the native module', async (fn, expected) => {
+    const mod = require('../index');
+    expect(typeof mod[fn]).toBe('function');
+    await expect(mod[fn]()).resolves.toBe(expected);
+    expect(mockNativeModule[fn]).toHaveBeenCalled();
+  });
+});
+
 describe('Persisted detection log parsing (iOS-only)', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/__tests__/permissions.test.ts
+++ b/src/__tests__/permissions.test.ts
@@ -77,6 +77,12 @@ describe('Permission Management', () => {
     // Reset default mock behavior
     mockPermissionsAndroid.check.mockResolvedValue(true);
     mockPermissionsAndroid.request.mockResolvedValue('granted');
+    // Native iOS getters back to defaults (implementations leak across tests
+    // that override them, since clearAllMocks/mockClear only clear call data).
+    mockNativeModule.checkPermissions.mockResolvedValue(true);
+    mockNativeModule.requestPermissions.mockResolvedValue(true);
+    mockNativeModule.checkNotificationPermission.mockResolvedValue(true);
+    mockNativeModule.getAuthorizationStatus.mockResolvedValue('always');
   });
 
   describe('checkPermissions()', () => {
@@ -278,6 +284,10 @@ describe('Permission Management', () => {
 
       it('should return false fields when native returns false', async () => {
         mockNativeModule.checkPermissions.mockResolvedValue(false);
+        // Notifications and background location are read from their own native
+        // checks now, not fabricated from the location boolean.
+        mockNativeModule.checkNotificationPermission.mockResolvedValue(false);
+        mockNativeModule.getAuthorizationStatus.mockResolvedValue('denied');
         const { checkPermissions } = require('../permissions');
 
         const result = await checkPermissions();
@@ -286,16 +296,34 @@ describe('Permission Management', () => {
           fineLocation: false,
           btScan: false,
           btConnect: false,
-          notifications: true,
+          notifications: false,
           backgroundLocation: false,
         });
+      });
+
+      it('should report notifications and backgroundLocation from real native checks', async () => {
+        mockNativeModule.checkPermissions.mockResolvedValue(true);
+        // Location authorized (whenInUse) but notifications denied, and only
+        // When-In-Use → backgroundLocation must be false.
+        mockNativeModule.checkNotificationPermission.mockResolvedValue(false);
+        mockNativeModule.getAuthorizationStatus.mockResolvedValue('whenInUse');
+        const { checkPermissions } = require('../permissions');
+
+        const result = await checkPermissions();
+
+        expect(result.notifications).toBe(false);
+        expect(result.backgroundLocation).toBe(false);
+
+        mockNativeModule.getAuthorizationStatus.mockResolvedValue('always');
+        const result2 = await checkPermissions();
+        expect(result2.backgroundLocation).toBe(true);
       });
     });
   });
 
   describe('requestForegroundPermissions()', () => {
     describe('Android', () => {
-      it('should request fine location permission on Android', async () => {
+      it('should request BLUETOOTH_SCAN and NOT location on Android 12+', async () => {
         jest.resetModules();
         jest.doMock('react-native', () => ({
           get Platform() {
@@ -326,10 +354,26 @@ describe('Permission Management', () => {
         const { requestForegroundPermissions } = require('../permissions');
         await requestForegroundPermissions();
 
-        expect(mockPermissionsAndroid.request).toHaveBeenCalled();
+        const requested = mockPermissionsAndroid.request.mock.calls.map(
+          (c: unknown[]) => c[0]
+        );
+        // On 12+ the scan is unlocked by BLUETOOTH_SCAN (neverForLocation).
+        expect(requested).toContain('android.permission.BLUETOOTH_SCAN');
+        expect(requested).toContain('android.permission.BLUETOOTH_CONNECT');
+        // Location must NOT be requested — asking for it only risks a Play flag.
+        expect(requested).not.toContain(
+          'android.permission.ACCESS_FINE_LOCATION'
+        );
+        expect(requested).not.toContain(
+          'android.permission.ACCESS_COARSE_LOCATION'
+        );
+        // Background location is never requested by the foreground flow.
+        expect(requested).not.toContain(
+          'android.permission.ACCESS_BACKGROUND_LOCATION'
+        );
       });
 
-      it('should request coarse location if fine is denied', async () => {
+      it('should request POST_NOTIFICATIONS on Android 13+', async () => {
         jest.resetModules();
         jest.doMock('react-native', () => ({
           get Platform() {
@@ -338,7 +382,44 @@ describe('Permission Management', () => {
                 return 'android';
               },
               get Version() {
-                return 31;
+                return 33;
+              },
+            };
+          },
+          NativeModules: { BearoundReactSdk: {} },
+          NativeEventEmitter: jest.fn(() => ({
+            addListener: jest.fn(() => ({ remove: jest.fn() })),
+          })),
+          PermissionsAndroid: mockPermissionsAndroid,
+          Linking: mockLinking,
+          TurboModuleRegistry: {
+            getEnforcing: jest.fn(() => mockNativeModule),
+          },
+        }));
+        jest.doMock('../NativeBearoundReactSdk', () => ({
+          __esModule: true,
+          default: mockNativeModule,
+        }));
+
+        const { requestForegroundPermissions } = require('../permissions');
+        await requestForegroundPermissions();
+
+        const requested = mockPermissionsAndroid.request.mock.calls.map(
+          (c: unknown[]) => c[0]
+        );
+        expect(requested).toContain('android.permission.POST_NOTIFICATIONS');
+      });
+
+      it('should request location with coarse fallback on Android < 12', async () => {
+        jest.resetModules();
+        jest.doMock('react-native', () => ({
+          get Platform() {
+            return {
+              get OS() {
+                return 'android';
+              },
+              get Version() {
+                return 30;
               },
             };
           },
@@ -368,9 +449,15 @@ describe('Permission Management', () => {
         const { requestForegroundPermissions } = require('../permissions');
         await requestForegroundPermissions();
 
-        // Should have made multiple requests: fine, coarse, bt_scan, bt_connect
-        // (notifications only on API 33+)
-        expect(mockPermissionsAndroid.request).toHaveBeenCalledTimes(4);
+        const requested = mockPermissionsAndroid.request.mock.calls.map(
+          (c: unknown[]) => c[0]
+        );
+        // ≤ 11: fine (denied) then coarse fallback; no Bluetooth runtime perms.
+        expect(requested).toContain('android.permission.ACCESS_FINE_LOCATION');
+        expect(requested).toContain(
+          'android.permission.ACCESS_COARSE_LOCATION'
+        );
+        expect(requested).not.toContain('android.permission.BLUETOOTH_SCAN');
       });
 
       it('should return permission result', async () => {
@@ -602,14 +689,16 @@ describe('Permission Management', () => {
         expect(result).toBe(false);
       });
 
-      it('should open settings when NEVER_ASK_AGAIN', async () => {
+      it('should NOT open settings on NEVER_ASK_AGAIN (host-app decision)', async () => {
         mockPermissionsAndroid.check.mockResolvedValue(true);
         mockPermissionsAndroid.request.mockResolvedValue('never_ask_again');
         const { requestBackgroundLocation } = require('../permissions');
 
-        await requestBackgroundLocation();
+        const result = await requestBackgroundLocation();
 
-        expect(mockLinking.openSettings).toHaveBeenCalled();
+        // Opening Settings is the host app's decision; the SDK just reports denial.
+        expect(mockLinking.openSettings).not.toHaveBeenCalled();
+        expect(result).toBe(false);
       });
 
       it('should return false if foreground location not granted on Android 29-30', async () => {
@@ -736,7 +825,7 @@ describe('Permission Management', () => {
         expect(mockPermissionsAndroid.request).toHaveBeenCalled();
       });
 
-      it('should request background location by default', async () => {
+      it('should NOT request background location by default', async () => {
         jest.resetModules();
         jest.doMock('react-native', () => ({
           get Platform() {
@@ -769,7 +858,48 @@ describe('Permission Management', () => {
         const { ensurePermissions } = require('../permissions');
         await ensurePermissions();
 
-        // Should have requested background location
+        // Background location is not a scan requirement — never requested by default.
+        const calls = mockPermissionsAndroid.request.mock.calls.map(
+          (c: unknown[]) => c[0]
+        );
+        expect(calls).not.toContain(
+          'android.permission.ACCESS_BACKGROUND_LOCATION'
+        );
+      });
+
+      it('should request background location only on explicit opt-in', async () => {
+        jest.resetModules();
+        jest.doMock('react-native', () => ({
+          get Platform() {
+            return {
+              get OS() {
+                return 'android';
+              },
+              get Version() {
+                return 31;
+              },
+            };
+          },
+          NativeModules: { BearoundReactSdk: {} },
+          NativeEventEmitter: jest.fn(() => ({
+            addListener: jest.fn(() => ({ remove: jest.fn() })),
+          })),
+          PermissionsAndroid: mockPermissionsAndroid,
+          Linking: mockLinking,
+          TurboModuleRegistry: {
+            getEnforcing: jest.fn(() => mockNativeModule),
+          },
+        }));
+        jest.doMock('../NativeBearoundReactSdk', () => ({
+          __esModule: true,
+          default: mockNativeModule,
+        }));
+        mockPermissionsAndroid.check.mockResolvedValue(true);
+        mockPermissionsAndroid.request.mockResolvedValue('granted');
+
+        const { ensurePermissions } = require('../permissions');
+        await ensurePermissions({ askBackground: true });
+
         const calls = mockPermissionsAndroid.request.mock.calls.map(
           (c: unknown[]) => c[0]
         );

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -37,6 +37,10 @@ export const mockNativeModule = {
   disableForegroundScanning: jest.fn(() => Promise.resolve()),
   isForegroundScanningEnabled: jest.fn(() => Promise.resolve(false)),
   setForegroundNotificationContent: jest.fn(() => Promise.resolve()),
+  isIgnoringBatteryOptimizations: jest.fn(() => Promise.resolve(true)),
+  openBatteryOptimizationSettings: jest.fn(() => Promise.resolve(true)),
+  isAutostartManageable: jest.fn(() => Promise.resolve(false)),
+  openManufacturerAutostartSettings: jest.fn(() => Promise.resolve(false)),
   addListener: jest.fn(),
   removeListeners: jest.fn(),
 };

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -21,6 +21,7 @@ export const mockNativeModule = {
   clearUserProperties: jest.fn(() => Promise.resolve()),
   checkPermissions: jest.fn(() => Promise.resolve(true)),
   requestPermissions: jest.fn(() => Promise.resolve(true)),
+  checkNotificationPermission: jest.fn(() => Promise.resolve(true)),
   getSdkVersion: jest.fn(() => Promise.resolve('3.0.0')),
   getCurrentScanPrecision: jest.fn(() => Promise.resolve('medium')),
   getBleDiagnosticInfo: jest.fn(() => Promise.resolve('')),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -622,6 +622,52 @@ export async function setForegroundNotificationContent(
   await Native.setForegroundNotificationContent(content as object);
 }
 
+// --- Background reliability (Android-only) ---
+
+/**
+ * Whether the app is exempt from Android battery optimizations (Doze). When
+ * `false`, aggressive power management can kill background/opportunistic
+ * scanning — the #1 cause of "stops detecting after a while" on Android.
+ *
+ * **Android-only.** iOS has no user-facing equivalent and always resolves
+ * `true` (nothing to exempt).
+ */
+export async function isIgnoringBatteryOptimizations(): Promise<boolean> {
+  return Native.isIgnoringBatteryOptimizations();
+}
+
+/**
+ * Open the system battery-optimization screen so the user can exempt the app
+ * (recommended when {@link isIgnoringBatteryOptimizations} returns `false`).
+ * Resolves `true` if a settings screen was launched.
+ *
+ * **Android-only** — iOS always resolves `false`.
+ */
+export async function openBatteryOptimizationSettings(): Promise<boolean> {
+  return Native.openBatteryOptimizationSettings();
+}
+
+/**
+ * Whether this device is from an OEM with a known autostart / protected-apps
+ * screen (Xiaomi/Huawei/Oppo/Vivo/...), where the app must be whitelisted to
+ * keep scanning after being swiped away or on reboot.
+ *
+ * **Android-only** — iOS always resolves `false`.
+ */
+export async function isAutostartManageable(): Promise<boolean> {
+  return Native.isAutostartManageable();
+}
+
+/**
+ * Open the manufacturer's autostart / protected-apps screen when one exists
+ * (see {@link isAutostartManageable}). Resolves `true` if a screen was launched.
+ *
+ * **Android-only** — iOS always resolves `false`.
+ */
+export async function openManufacturerAutostartSettings(): Promise<boolean> {
+  return Native.openManufacturerAutostartSettings();
+}
+
 export function addBeaconsListener(
   listener: (beacons: Beacon[]) => void
 ): EmitterSubscription {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -9,21 +9,19 @@
  *   PermissionsAndroid API. Permissions must be explicitly requested and managed.
  * - **iOS**: Permission requests are handled via native helper methods.
  *
- * **Required Permissions:**
- * - Location (fine/coarse): Required for Bluetooth beacon scanning
- * - Bluetooth scan/connect: Required on Android 12+ for BLE operations
- * - Notifications: Used for background monitoring indicators
- * - Background location: Enables beacon detection when app is backgrounded
+ * **What actually gates the scan (Android):**
+ * - **Android 12+ (API 31+):** `BLUETOOTH_SCAN` (declared `neverForLocation`).
+ *   Location does NOT unlock the BLE scan on these releases.
+ * - **Android ≤ 11 (API ≤ 30):** fine/coarse location gates the BLE scan.
+ * - `POST_NOTIFICATIONS` (Android 13+): optional, for foreground-service /
+ *   monitoring indicators — not required to scan.
+ * - `ACCESS_BACKGROUND_LOCATION`: NOT a scan requirement; requested only via the
+ *   explicit {@link requestBackgroundLocation} opt-in.
  *
  * @author Bearound Team
  */
 
-import {
-  PermissionsAndroid,
-  Platform,
-  Linking,
-  type Permission,
-} from 'react-native';
+import { PermissionsAndroid, Platform, type Permission } from 'react-native';
 
 import Native from './NativeBearoundReactSdk';
 /**
@@ -144,21 +142,25 @@ export async function checkPermissions(): Promise<PermissionResult> {
  * - **Android**: Shows system permission dialogs and requests permissions interactively
  * - **iOS**: Requests location permission via native helper
  *
- * **Permissions Requested (Android only):**
- * - Fine location (with fallback to coarse location)
- * - Bluetooth scan (Android 12+)
- * - Bluetooth connect (Android 12+)
- * - Post notifications (Android 13+)
+ * **Permissions Requested (Android only), gated by API level:**
+ * - **Android 12+ (API 31+):** `BLUETOOTH_SCAN` (+ `BLUETOOTH_CONNECT`) and,
+ *   on 13+, the optional `POST_NOTIFICATIONS`. Location is **not** requested —
+ *   the SDK declares `BLUETOOTH_SCAN` with `neverForLocation`, so location does
+ *   not unlock the BLE scan and asking for it only risks a Play review flag.
+ * - **Android < 12 (API ≤ 30):** fine location (with coarse fallback), which is
+ *   what gates the BLE scan on those releases.
  *
- * The function presents user-friendly dialogs in Portuguese with explanations
- * for why each permission is needed.
+ * Background location is **never** requested here — it is not a scan requirement
+ * and, undeclared, resolves to `NEVER_ASK_AGAIN`. Request it explicitly via
+ * {@link requestBackgroundLocation} only if the host app truly needs it.
  *
  * @returns Promise<PermissionResult> Updated permission status after requests
  *
  * @example
  * ```typescript
  * const result = await requestForegroundPermissions();
- * if (result.fineLocation && result.btScan) {
+ * // Android 12+: gate on btScan. Android ≤ 11: gate on fineLocation.
+ * if (result.btScan || result.fineLocation) {
  *   // Ready to start scanning for beacons
  * }
  * ```
@@ -191,56 +193,44 @@ export async function requestForegroundPermissions(): Promise<PermissionResult> 
     return res === PermissionsAndroid.RESULTS.GRANTED;
   };
 
-  let fineGranted = await req(
+  if (SDK_INT >= 31) {
+    // Android 12+: the scan is unlocked by BLUETOOTH_SCAN (neverForLocation),
+    // not by location. Request only Bluetooth (+ optional notifications).
+    await req(
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+      'Permissão de Bluetooth',
+      'Precisamos de acesso ao Bluetooth para escanear beacons.'
+    );
+    await req(
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+      'Permissão de Conexão Bluetooth',
+      'Necessário para interagir com dispositivos BLE.'
+    );
+    if (SDK_INT >= 33) {
+      await req(
+        PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+        'Permissão de Notificações',
+        'Usamos notificações para indicar o monitoramento em andamento.'
+      );
+    }
+    return checkPermissions();
+  }
+
+  // Android ≤ 11: fine location (with coarse fallback) gates the BLE scan.
+  const fineGranted = await req(
     PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
     'Permissão de Localização',
     'Precisamos de localização para escanear beacons via Bluetooth.'
   );
-
-  let coarseGranted = false;
   if (!fineGranted) {
-    coarseGranted = await req(
+    await req(
       PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION,
       'Permissão de Localização Aproximada',
       'Se preferir, conceda localização aproximada para permitir o escaneamento.'
     );
   }
 
-  const btScan =
-    SDK_INT >= 31
-      ? await req(
-          PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
-          'Permissão de Bluetooth',
-          'Precisamos de acesso ao Bluetooth para escanear beacons.'
-        )
-      : true;
-
-  const btConnect =
-    SDK_INT >= 31
-      ? await req(
-          PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
-          'Permissão de Conexão Bluetooth',
-          'Necessário para interagir com dispositivos BLE.'
-        )
-      : true;
-
-  const notifications =
-    SDK_INT >= 33
-      ? await req(
-          PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
-          'Permissão de Notificações',
-          'Usamos notificações para indicar o monitoramento em andamento.'
-        )
-      : true;
-
-  const current = await checkPermissions();
-  return {
-    ...current,
-    fineLocation: current.fineLocation || fineGranted || coarseGranted,
-    btScan: current.btScan || btScan,
-    btConnect: current.btConnect || btConnect,
-    notifications: current.notifications || notifications,
-  };
+  return checkPermissions();
 }
 
 /**
@@ -253,21 +243,24 @@ export async function requestForegroundPermissions(): Promise<PermissionResult> 
  * **Android Behavior:**
  * - Requires foreground location permission first (Android 10)
  * - On Android 12+, background location can be requested without foreground fine location
- * - If user selects "Never ask again", automatically opens app settings
  * - Only available on Android 10+ (API 29+)
  *
- * **Important:** Background location is essential for detecting beacons when the app
- * is backgrounded or closed, enabling geofencing and proximity features.
+ * **Not a scan requirement.** The Bearound BLE scan does not need background
+ * location; on 12+ it is gated by `BLUETOOTH_SCAN` (`neverForLocation`). Only
+ * call this if the host app has its own reason to hold background location, and
+ * make sure `ACCESS_BACKGROUND_LOCATION` is declared in the app manifest —
+ * otherwise the request resolves to `NEVER_ASK_AGAIN`.
+ *
+ * This never opens app Settings on your behalf; if the return value indicates
+ * a permanent denial the host app decides whether to route the user there.
  *
  * @returns Promise<boolean> true if background location permission is granted
  *
  * @example
  * ```typescript
  * const hasBackground = await requestBackgroundLocation();
- * if (hasBackground) {
- *   // Can detect beacons in background
- * } else {
- *   // Limited to foreground detection only
+ * if (!hasBackground) {
+ *   // Denied — the host app decides whether to open Settings (Linking.openSettings()).
  * }
  * ```
  */
@@ -294,10 +287,8 @@ export async function requestBackgroundLocation(): Promise<boolean> {
     }
   );
 
-  if (res === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
-    await Linking.openSettings();
-  }
-
+  // Intentionally does NOT open Settings on NEVER_ASK_AGAIN — opening Settings
+  // is a host-app decision. The caller inspects the boolean and acts.
   return res === PermissionsAndroid.RESULTS.GRANTED;
 }
 
@@ -309,27 +300,34 @@ export async function requestBackgroundLocation(): Promise<boolean> {
  * - **iOS**: Requests location permission via native helper
  *
  * This is the recommended function to call during app initialization to ensure
- * the Bearound SDK has all required permissions.
+ * the Bearound SDK has the permissions it needs to scan.
  *
  * **Flow:**
- * 1. Requests all foreground permissions (location, Bluetooth, notifications)
- * 2. Optionally requests background location permission
- * 3. Returns final permission status
+ * 1. Requests the foreground scan permissions for the running API level
+ *    (Android 12+: Bluetooth + optional notifications; ≤ 11: location).
+ * 2. Returns final permission status.
+ *
+ * Background location is **not** requested by default — it is not a scan
+ * requirement and, undeclared, resolves to `NEVER_ASK_AGAIN`. Opt in with
+ * `{ askBackground: true }` only if the host app has declared
+ * `ACCESS_BACKGROUND_LOCATION` and truly needs it. This function never opens
+ * app Settings on your behalf.
  *
  * @param opts - Configuration options
- * @param opts.askBackground - Whether to request background location permission (default: true)
+ * @param opts.askBackground - Whether to also request background location
+ *   (Android-only opt-in; default: `false`)
  * @returns Promise<PermissionResult> Final status of all permissions
  *
  * @example
  * ```typescript
- * // Request all permissions including background
+ * // Basic flow — foreground scan permissions only (recommended)
  * const permissions = await ensurePermissions();
  *
- * // Skip background location request
- * const permissions = await ensurePermissions({ askBackground: false });
+ * // Explicit opt-in for background location (must be declared in the manifest)
+ * const permissions = await ensurePermissions({ askBackground: true });
  * ```
  */
-export async function ensurePermissions(opts = { askBackground: true }) {
+export async function ensurePermissions(opts = { askBackground: false }) {
   await requestForegroundPermissions();
   if (opts.askBackground && isAndroid) {
     await requestBackgroundLocation();

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -80,13 +80,23 @@ const has = async (p?: Permission) =>
  */
 export async function checkPermissions(): Promise<PermissionResult> {
   if (!isAndroid) {
-    const granted = await Native.checkPermissions();
+    // iOS: fineLocation/btScan/btConnect mirror the single location boolean the
+    // native bridge exposes (authorizedAlways OR authorizedWhenInUse). For the
+    // real Bluetooth permission use getBluetoothState() ('unauthorized' = denied).
+    const [granted, notifications, authStatus] = await Promise.all([
+      Native.checkPermissions(),
+      // Real UNUserNotificationCenter check (authorized/provisional/ephemeral).
+      Native.checkNotificationPermission(),
+      Native.getAuthorizationStatus(),
+    ]);
     return {
       fineLocation: granted,
       btScan: granted,
       btConnect: granted,
-      notifications: true,
-      backgroundLocation: granted,
+      notifications,
+      // Only authorizedAlways counts — When-In-Use does not allow the
+      // terminated-app wake-up that "background location" implies.
+      backgroundLocation: authStatus === 'always',
     };
   }
 
@@ -155,13 +165,19 @@ export async function checkPermissions(): Promise<PermissionResult> {
  */
 export async function requestForegroundPermissions(): Promise<PermissionResult> {
   if (!isAndroid) {
+    // iOS: requests location authorization (Always) while notDetermined; the
+    // remaining fields are read back honestly (see checkPermissions).
     const granted = await Native.requestPermissions();
+    const [notifications, authStatus] = await Promise.all([
+      Native.checkNotificationPermission(),
+      Native.getAuthorizationStatus(),
+    ]);
     return {
       fineLocation: granted,
       btScan: granted,
       btConnect: granted,
-      notifications: true,
-      backgroundLocation: granted,
+      notifications,
+      backgroundLocation: authStatus === 'always',
     };
   }
 


### PR DESCRIPTION
## Auditoria de DX + bump 3.4.5 — react-native

[Auditoria de DX](../AUDITORIA-DX-SDKS.md) do wrapper RN, incluindo o **bump para 3.4.5** (o RN estava travado em 3.4.2, sem os fixes de FGS/permissão). Base = `main`.

### Docs
- Claims alinhados ao código: "3.3.1"→versões reais, minSdk real, dependência CocoaPods (não "vendored").
- **Quick Start corrigido**: o gate Android 12+ atual (`fineLocation && btConnect && backgroundLocation`) **nunca passa** → trocado por BLUETOOTH_SCAN (+ notifications 13+); `configure()` no mount, não atrás de botão (quebra o push swizzle).
- Troubleshooting reescrito para o modelo 3.x (battery-opt/OEM, FGS+vídeo, silent push iOS, 0xBEAD). `setPushToken` documentado. Semântica real do `PermissionResult` iOS. README do example real.

### Código (não-breaking)
- **`PermissionResult` iOS deixa de mentir**: `notifications` = check real (UNUserNotificationCenter); `backgroundLocation` = `authorizedAlways` (não whenInUse). Antes eram hardcoded.
- **`ensurePermissions`**: não pede `ACCESS_BACKGROUND_LOCATION` por default (evita NEVER_ASK_AGAIN); **nunca abre Settings automaticamente**; gate por `SDK_INT` (12+ = BLUETOOTH_SCAN).
- **Reliability helpers** (paridade com Flutter 3.4.5): battery-opt + OEM autostart, delegando ao SDK nativo; no-ops iOS + tipos TS.
- **Bump 3.4.5** (nativos Android/iOS) + CHANGELOG. CI: version-match tag↔package.json + GitHub Release no publish.

### Validação
typecheck (tsc) / lint / testes conforme o repo. Revisor: PASS.

⚠️ **Draft**. Build Android do example depende da tag `v3.4.5` do android-sdk no JitPack (esperado).
