### PR TITLE
fix(ios): implementar ponte setPushToken (crash) + registro APNs no example

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -11,6 +11,7 @@ gem 'concurrent-ruby', '< 1.3.4'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'base64'
+gem 'nkf' # provides `kconv`, which CocoaPods/xcodeproj require on Ruby 3.4
 gem 'bigdecimal'
 gem 'logger'
 gem 'benchmark'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
+    nkf (0.3.0)
     public_suffix (4.0.7)
     rexml (3.4.4)
     ruby-macho (2.5.1)
@@ -104,6 +105,7 @@ DEPENDENCIES
   concurrent-ruby (< 1.3.4)
   logger
   mutex_m
+  nkf
   xcodeproj (< 1.26.0)
 
 RUBY VERSION

--- a/example/ios/BearoundReactSdkExample/AppDelegate.swift
+++ b/example/ios/BearoundReactSdkExample/AppDelegate.swift
@@ -46,6 +46,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
       }
     }
 
+    // Register for remote (silent) push — the ONLY vector that wakes a
+    // user-force-quit app on iOS. This triggers APNs registration; the raw
+    // token arrives in didRegisterForRemoteNotificationsWithDeviceToken below.
+    // Requires the app target to have the Push Notifications capability
+    // (the signed `aps-environment` entitlement) — no SDK can add it for you.
+    application.registerForRemoteNotifications()
+
     // If iOS relaunched us due to a region/bluetooth event, surface it immediately
     // (the SDK auto-restores scanning from storage; we don't reconfigure here so
     // the user's saved scan precision is preserved).
@@ -85,6 +92,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     BeAroundSDK.shared.performBackgroundFetch { success in
       completionHandler(success ? .newData : .noData)
     }
+  }
+
+  // Raw APNs token → SDK. The backend pushes via APNs (not FCM), so we forward
+  // the RAW device token. The SDK also auto-captures it via swizzle, but
+  // forwarding explicitly is the robust path (the swizzle is intercepted when
+  // Firebase is present). Idempotent — setting the same token twice is a no-op.
+  func application(
+    _ application: UIApplication,
+    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+  ) {
+    let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+    NSLog("[BearoundReactSdkExample] APNs token registered (%d bytes)", deviceToken.count)
+    BeAroundSDK.shared.setPushToken(token)
+  }
+
+  func application(
+    _ application: UIApplication,
+    didFailToRegisterForRemoteNotificationsWithError error: Error
+  ) {
+    // Common cause: the Push Notifications capability / aps-environment
+    // entitlement is missing from the app target (nothing the SDK can fix).
+    NSLog("[BearoundReactSdkExample] APNs registration failed: %@", error.localizedDescription)
   }
 
   // Silent push (cold-launch race): the SDK's push swizzle only installs once

--- a/ios/BearoundReactSdk.mm
+++ b/ios/BearoundReactSdk.mm
@@ -192,6 +192,25 @@ maxQueuedPayloads:(double)maxQueuedPayloads
   resolve(nil);
 }
 
+// Forwards the device push token (raw APNs on iOS) to the native SDK, which
+// associates it with the deviceId and sends it on the next sync. Declared in
+// the codegen spec and implemented by RNBearoundBridge, but the TurboModule
+// bridge method was missing — calling it on iOS raised an unrecognized-selector
+// crash, breaking the manual-APNs-token path (needed when Firebase intercepts
+// the swizzle). See RNBearoundBridge.setPushToken.
+- (void)setPushToken:(NSString *)token
+             resolve:(RCTPromiseResolveBlock)resolve
+              reject:(RCTPromiseRejectBlock)reject
+{
+  NSString *value = token ?: @"";
+  if (value.length == 0) {
+    reject(@"INVALID_ARGUMENT", @"token is required", nil);
+    return;
+  }
+  [[RNBearoundBridge shared] setPushToken:value];
+  resolve(nil);
+}
+
 - (void)isIgnoringBatteryOptimizations:(RCTPromiseResolveBlock)resolve
                                 reject:(RCTPromiseRejectBlock)reject
 {


### PR DESCRIPTION
## Contexto
A auditoria de prontidão do **background scan** achou o caminho de push do iOS quebrado ponta a ponta no wrapper RN.

## O que estava quebrado
1. **`Native.setPushToken()` crashava no iOS** (`unrecognized selector`). O método está no codegen spec (`NativeBearoundReactSdk.ts`) e o `RNBearoundBridge.setPushToken` implementa — mas **faltava a ponte TurboModule** no `ios/BearoundReactSdk.mm`. Qualquer app RN chamando `setPushToken` (o caminho manual de APNs, necessário quando o Firebase intercepta o swizzle) crashava.
2. O **AppDelegate do example** tinha os *handlers* de silent push mas **nunca registrava no APNs** → nunca obtinha token → o silent push (único vetor que acorda app force-quit no iOS) nunca chegava.

## Fix
- `BearoundReactSdk.mm`: adicionada a ponte `setPushToken:resolve:reject:` (padrão idêntico aos outros 30 métodos) → `[[RNBearoundBridge shared] setPushToken:]`.
- `AppDelegate.swift` (example): `registerForRemoteNotifications()` + `didRegisterForRemoteNotificationsWithDeviceToken` (encaminha o **token APNs cru** — backend usa APNs, não FCM) + `didFailToRegister`.

## Passo que continua sendo do CLIENTE (config do host, nenhum SDK faz por ele)
Habilitar a capability **Push Notifications** (entitlement `aps-environment`) no target + bundle real com credencial APNs. Documentado no README do SDK.

## Validação
`yarn typecheck` + `yarn lint` limpos (0 erros). Swift/ObjC revisado (segue o padrão existente do repo).

Contexto: gap #2 da matriz de prontidão de background scan; pareado com a ação operacional #1 (cadastrar credencial APNs de produção do Car Media, 430 devices iOS).