### PR TITLE
docs: AI-agent setup section + copyable prompt ("Copy for LLM")

### DIFF
--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -1,0 +1,51 @@
+# Bearound React Native — AI agent setup prompt
+
+Copy everything in the code block below and paste it into your AI coding agent
+(Claude Code, Cursor, Copilot, …) with this app's repo open. The agent reads the
+[SDK README](./README.md) and wires the full iOS/Android background integration.
+
+On GitHub, hover the block and click the **copy icon** in its top-right corner to
+copy it in one click. Or point a web-capable agent straight at this file's raw URL:
+`https://raw.githubusercontent.com/Bearound/bearound-react-native-sdk/main/AI-AGENT-SETUP.md`
+
+```text
+Integrate @bearound/react-native-sdk into this React Native app. First READ the
+SDK's README end to end — especially "iOS Background Integration (required)",
+"Permission Configuration", and "Quick Start" — then do ALL of the following,
+matching the README's proven-working example EXACTLY:
+
+1. Install: `npm i @bearound/react-native-sdk`, then `cd ios && pod install`.
+
+2. iOS AppDelegate (§1): wire the COMPLETE AppDelegate from README §1 into this
+   app's AppDelegate — EVERY method, none optional: the SDK delegate,
+   registerBackgroundTasks, the UNUserNotificationCenter delegate +
+   requestAuthorization, application.registerForRemoteNotifications(),
+   launchOptions handling, performFetch,
+   didRegisterForRemoteNotificationsWithDeviceToken -> setPushToken,
+   didFailToRegister, the `bearound` silent-push handler,
+   handleEventsForBackgroundURLSession, and willPresent. Use THIS app's own
+   registered module name in startReactNative (do NOT leave the placeholder).
+   If the app still ships the Objective-C AppDelegate.mm, port the same calls there.
+
+3. iOS Info.plist: add the five UIBackgroundModes, the two
+   BGTaskSchedulerPermittedIdentifiers (io.bearound.sdk.sync,
+   io.bearound.sdk.processing), and the four NS…UsageDescription strings — write
+   a user-facing rationale that matches what THIS app actually does (no internal
+   jargon). Then run `plutil -lint` and confirm it prints OK.
+
+4. JS (§4 / Quick Start): call configure({ businessToken: <ASK ME FOR IT> }) on
+   root-component mount (useEffect), then startScanning(); on Android also call
+   enableForegroundScanning() after startScanning().
+
+5. Verify (§6): run the plutil checks and give me the 3-state field-test checklist
+   (foreground / background / terminated).
+
+Guardrails — follow strictly:
+- NEVER rely on the push swizzle alone; forward the RAW APNs token explicitly.
+- The SDK must NEVER crash the host app.
+- Ask me for my businessToken; do not invent one.
+- STOP and hand me click-by-click steps for anything only a human can do: the
+  Xcode Push Notifications capability with my provisioning profile, on-device
+  permission grants (Always location + Background App Refresh), and the Google
+  Play foreground-service declaration. Do not attempt those yourself.
+```

--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -8,43 +8,100 @@ the full iOS/Android background integration.
 ```text
 Integrate @bearound/react-native-sdk into this React Native app. First READ the
 SDK's README end to end — especially "iOS Background Integration (required)",
-"Permission Configuration", and "Quick Start" — then do ALL of the following,
-matching the README's proven-working example EXACTLY:
+"Permission Configuration", "Quick Start", and "Set up with an AI agent" — then do
+ALL of the following. Follow the README's Quick Start and §1-§6; where a step below
+is more specific, it wins.
 
-1. Install: `npm i @bearound/react-native-sdk`, then `cd ios && pod install`.
+1. Install: `npm i @bearound/react-native-sdk`, then `cd ios && pod install`. If this
+   app's Podfile uses `use_frameworks!`, set `use_frameworks! :linkage => :static`
+   before running pod install.
 
-2. iOS AppDelegate (§1): wire the COMPLETE AppDelegate from README §1 into this
-   app's AppDelegate — EVERY method, none optional: the SDK delegate,
-   registerBackgroundTasks, the UNUserNotificationCenter delegate +
-   requestAuthorization, application.registerForRemoteNotifications(),
-   launchOptions handling, performFetch,
-   didRegisterForRemoteNotificationsWithDeviceToken -> setPushToken,
-   didFailToRegister, the `bearound` silent-push handler,
-   handleEventsForBackgroundURLSession, and willPresent. Use THIS app's own
-   registered module name in startReactNative (do NOT leave the placeholder).
-   If the app still ships the Objective-C AppDelegate.mm, port the same calls there.
+2. iOS AppDelegate (§1) — the AppDelegate MUST be Swift: BeAroundSDK is pure, non-@objc
+   Swift, unreachable from Objective-C, so NEVER wire BeAround calls into an
+   AppDelegate.mm. MERGE into the existing AppDelegate, do NOT overwrite it. First check
+   the RN version, then PERFORM the right conversion yourself — this is the standard RN
+   Swift-AppDelegate migration and IS your job, do not hand it back:
+   - RN >= 0.77 (already Swift, symbols RCTReactNativeFactory / ReactNativeDelegate /
+     RCTAppDependencyProvider): use the §1 template as-is.
+   - RN 0.73-0.76 (ships AppDelegate.mm / subclasses RCTAppDelegate): convert the target
+     to a Swift AppDelegate that SUBCLASSES RCTAppDelegate and carries the SAME BeAround
+     calls — delete the .mm/.h, add a `<App>-Bridging-Header.h` importing RN's ObjC
+     headers, set SWIFT_OBJC_BRIDGING_HEADER. Do NOT paste the RCTReactNativeFactory
+     symbols here (they don't exist pre-0.77). Only STOP and hand ME click-by-click steps
+     if the existing .mm has heavy custom native wiring (other SDKs' delegate setup) you
+     can't safely port.
+   Wire EVERY §1 method — none optional: the SDK delegate (RNBearoundBridge.shared),
+   registerBackgroundTasks, requestAuthorization, application.registerForRemoteNotifications(),
+   launchOptions handling, performFetch, didRegisterForRemoteNotificationsWithDeviceToken ->
+   setPushToken, didFailToRegister, the `bearound` silent-push handler,
+   handleEventsForBackgroundURLSession, and willPresent — while PRESERVING all existing
+   app/Firebase/other-native-module code. For EVERY method the target already implements
+   (didFinishLaunching, willPresent, performFetch, didReceiveRemoteNotification,
+   didRegister/didFailToRegister, handleEventsForBackgroundURLSession), ADD the BeAround
+   call INSIDE it — fold the `userInfo["bearound"]` guard into the existing push handler —
+   NEVER declare a duplicate. Set `UNUserNotificationCenter.current().delegate = self`
+   ONLY if nothing else owns it; if the host or Firebase/notifee already assigns the
+   notification-center delegate, inject BeAround's willPresent / didReceiveNotification
+   logic into THAT existing delegate object instead — reassigning silently STEALS the
+   host's push and foreground-notification routing. Replace the file wholesale only for a
+   stock, unmodified AppDelegate. Use THIS app's own registered module name in
+   startReactNative (do NOT leave the placeholder).
 
-3. iOS Info.plist: add the five UIBackgroundModes, the two
-   BGTaskSchedulerPermittedIdentifiers (io.bearound.sdk.sync,
-   io.bearound.sdk.processing), and the four NS…UsageDescription strings — write
-   a user-facing rationale that matches what THIS app actually does (no internal
-   jargon). Then run `plutil -lint` and confirm it prints OK.
+3. iOS Info.plist: add the five UIBackgroundModes (fetch, location, processing,
+   bluetooth-central, remote-notification), the two BGTaskSchedulerPermittedIdentifiers
+   (io.bearound.sdk.sync, io.bearound.sdk.processing), and the four
+   NS…UsageDescription strings — write a user-facing rationale that matches what THIS
+   app actually does (no internal jargon). Then run `plutil -lint` and confirm OK.
 
-4. JS (§4 / Quick Start): call configure({ businessToken: <ASK ME FOR IT> }) on
-   root-component mount (useEffect), then startScanning(); on Android also call
-   enableForegroundScanning() after startScanning().
+4. JS — configure, THEN request permissions, THEN scan (order matters; follow the
+   README Quick Start): on root-component mount call
+   `configure({ businessToken: <ASK ME FOR IT> })`. Then request permissions BEFORE
+   scanning: `const status = await ensurePermissions({ askBackground: false })` and,
+   on iOS, `await requestLocationAuthorization('always')` so CoreLocation region
+   monitoring can arm (without Always, background/terminated wake is dead). Gate
+   startScanning on the platform result — Android 12+: status.btScan; Android <=11:
+   status.fineLocation; iOS: proceed. Only THEN `await startScanning()`. On Android,
+   do NOT hard-code enableForegroundScanning() — ASK ME which scan mode to use: the
+   foreground-service mode (reliable background, survives OEM kills, but requires a
+   Google Play connectedDevice declaration + demo video) or the opportunistic default
+   (no Play video, lower battery). Call `await enableForegroundScanning()` ONLY if I
+   choose the foreground service; if I do, also on Android 13+ read status.notifications
+   and, if false, prompt me to enable notifications so the foreground-service
+   notification is visible. Do NOT call startScanning unconditionally and do NOT skip
+   ensurePermissions — without it, iOS is foreground-only and Android 12+ detects
+   NOTHING.
 
-5. Verify (§6): run the plutil checks and give me the 3-state field-test checklist
-   (foreground / background / terminated).
+5. Verify: run `plutil -lint` / `plutil -p` (all five modes + both BGTask ids), and in
+   code confirm the JS actually wires ensurePermissions() /
+   requestLocationAuthorization('always') and gates startScanning() on the grant. Then
+   BUILD iOS and confirm it COMPILES —
+   `cd ios && xcodebuild -workspace <app>.xcworkspace -scheme <app> -sdk iphonesimulator build`
+   (or build in Xcode); plutil passing is NOT proof the Swift compiles. BUILD Android too
+   — `cd android && ./gradlew assembleDebug` — then confirm the MERGED manifest
+   (app/build/…/merged_manifests/…/AndroidManifest.xml) still carries `BLUETOOTH_SCAN`
+   with `neverForLocation`; if the flag was dropped, a host redeclaration is missing it
+   (fix per §Permission Configuration). Also confirm the target `.entitlements` declares
+   `aps-environment` AND `CODE_SIGN_ENTITLEMENTS` points at it in BOTH the Debug AND
+   Release configs; if not, explicitly report "terminated-state silent-push wake is NOT
+   wired yet — needs §3 (human)". Background and terminated detection stay UNVERIFIED
+   until the human runs the on-device 3-state field test — do NOT report terminated-state
+   support as done from a foreground run.
 
 Guardrails — follow strictly:
 - NEVER rely on the push swizzle alone; forward the RAW APNs token explicitly.
+- NEVER reassign the UNUserNotificationCenter delegate if the host/Firebase/notifee
+  already owns it — inject BeAround's logic into the existing delegate instead.
 - The SDK must NEVER crash the host app.
-- Ask me for my businessToken; do not invent one.
-- STOP and hand me click-by-click steps for anything only a human can do: the
-  Xcode Push Notifications capability with my provisioning profile, on-device
-  permission grants (Always location + Background App Refresh), and the Google
-  Play foreground-service declaration. Do not attempt those yourself.
+- Ask me for my businessToken; do not invent one, and never reuse any token from
+  the SDK's example app.
+- STOP and hand me click-by-click steps for anything only a human can do: the Xcode
+  Push Notifications capability with my provisioning profile — set aps-environment to
+  `development` for Debug and `production` for Release (a Release/TestFlight build
+  left on development silently fails the silent-push wake in production), with
+  CODE_SIGN_ENTITLEMENTS pointing at the .entitlements in BOTH build configs; the
+  on-device permission grants (Always location + Background App Refresh); and the
+  Google Play connectedDevice foreground-service declaration + demo video. Do not
+  attempt those yourself.
 ```
 
 Web-capable agents can fetch this prompt directly from its raw URL:

--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -1,12 +1,9 @@
 # Bearound React Native — AI agent setup prompt
 
-Copy everything in the code block below and paste it into your AI coding agent
-(Claude Code, Cursor, Copilot, …) with this app's repo open. The agent reads the
-[SDK README](./README.md) and wires the full iOS/Android background integration.
-
-On GitHub, hover the block and click the **copy icon** in its top-right corner to
-copy it in one click. Or point a web-capable agent straight at this file's raw URL:
-`https://raw.githubusercontent.com/Bearound/bearound-react-native-sdk/main/AI-AGENT-SETUP.md`
+Hover the block below and click the **copy icon** in its top-right corner to copy
+the prompt, then paste it into your AI coding agent (Claude Code, Cursor, Copilot, …)
+with your app's repo open. The agent reads the [SDK README](./README.md) and wires
+the full iOS/Android background integration.
 
 ```text
 Integrate @bearound/react-native-sdk into this React Native app. First READ the
@@ -49,3 +46,6 @@ Guardrails — follow strictly:
   permission grants (Always location + Background App Refresh), and the Google
   Play foreground-service declaration. Do not attempt those yourself.
 ```
+
+Web-capable agents can fetch this prompt directly from its raw URL:
+`https://raw.githubusercontent.com/Bearound/bearound-react-native-sdk/main/AI-AGENT-SETUP.md`

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Guardrails — follow strictly:
   Do not attempt those yourself.
 ```
 
+> **Grab it in one click.** On GitHub, hover the block above and click the **copy icon** in its top-right corner. Prefer a link? Open [`AI-AGENT-SETUP.md`](./AI-AGENT-SETUP.md) — the same prompt on its own page — or point a web-capable agent straight at its [raw URL](https://raw.githubusercontent.com/Bearound/bearound-react-native-sdk/main/AI-AGENT-SETUP.md).
+
 **The agent will pause for these human-only steps** — they need your Apple/Google accounts and a physical device, so no SDK or agent can do them:
 
 - **Xcode → Push Notifications capability** on your app target, signed with **your** push-enabled App ID / provisioning profile. Set `aps-environment` to `development` for Debug and `production` for Release — see [§3](#3-push-notifications-capability-silent-push-wake-vector).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Aligned with Bearound native SDKs **3.4.2** (exact pins live in `android/build.g
 
 * [Requirements](#requirements)
 * [Installation](#installation)
+* [Set up with an AI agent](#set-up-with-an-ai-agent)
 * [Permission Configuration](#permission-configuration)
   * [Android – Manifest](#android--manifest)
   * [iOS – Info.plist and Background Modes](#ios--infoplist-and-background-modes)
@@ -70,6 +71,62 @@ pod install
 ### Android
 
 No additional Gradle configuration is needed beyond permissions. The native Android SDK is resolved as a module dependency.
+
+---
+
+## Set up with an AI agent
+
+The iOS/Android background wiring is intricate — but this README is written to be **agent-readable**: every step is explicit, copy-pasteable, and tied to the proven-working example. So instead of doing it by hand, you can hand the whole thing to an **AI coding agent** (Claude Code, Cursor, Copilot, …) and have it do the integration for you.
+
+**Point your agent at this README** — the local copy at `node_modules/@bearound/react-native-sdk/README.md` or the [GitHub page](https://github.com/Bearound/bearound-react-native-sdk) — and paste this prompt:
+
+```text
+Integrate @bearound/react-native-sdk into this React Native app. First READ the
+SDK's README end to end — especially "iOS Background Integration (required)",
+"Permission Configuration", and "Quick Start" — then do ALL of the following,
+matching the README's proven-working example EXACTLY:
+
+1. Install: `npm i @bearound/react-native-sdk`, then `cd ios && pod install`.
+
+2. iOS AppDelegate (§1): wire the COMPLETE AppDelegate from README §1 into this
+   app's AppDelegate — EVERY method, none optional: the SDK delegate,
+   registerBackgroundTasks, the UNUserNotificationCenter delegate +
+   requestAuthorization, application.registerForRemoteNotifications(),
+   launchOptions handling, performFetch,
+   didRegisterForRemoteNotificationsWithDeviceToken -> setPushToken,
+   didFailToRegister, the `bearound` silent-push handler,
+   handleEventsForBackgroundURLSession, and willPresent. Use THIS app's own
+   registered module name in startReactNative (do NOT leave the placeholder).
+   If the app still ships the Objective-C AppDelegate.mm, port the same calls there.
+
+3. iOS Info.plist: add the five UIBackgroundModes, the two
+   BGTaskSchedulerPermittedIdentifiers (io.bearound.sdk.sync,
+   io.bearound.sdk.processing), and the four NS…UsageDescription strings — write
+   a user-facing rationale that matches what THIS app actually does (no internal
+   jargon). Then run `plutil -lint` and confirm it prints OK.
+
+4. JS (§4 / Quick Start): call configure({ businessToken: <ASK ME FOR IT> }) on
+   root-component mount (useEffect), then startScanning(); on Android also call
+   enableForegroundScanning() after startScanning().
+
+5. Verify (§6): run the plutil checks and give me the 3-state field-test checklist
+   (foreground / background / terminated).
+
+Guardrails — follow strictly:
+- NEVER rely on the push swizzle alone; forward the RAW APNs token explicitly.
+- The SDK must NEVER crash the host app.
+- Ask me for my businessToken; do not invent one.
+- STOP and hand me click-by-click steps for anything only a human can do (below).
+  Do not attempt those yourself.
+```
+
+**The agent will pause for these human-only steps** — they need your Apple/Google accounts and a physical device, so no SDK or agent can do them:
+
+- **Xcode → Push Notifications capability** on your app target, signed with **your** push-enabled App ID / provisioning profile. Set `aps-environment` to `development` for Debug and `production` for Release — see [§3](#3-push-notifications-capability-silent-push-wake-vector).
+- **On device:** grant **Always** location and turn on **Background App Refresh**.
+- **Google Play:** the `connectedDevice` foreground-service declaration + demonstration video required at review — see [Scan modes](#scan-modes-android).
+
+Prefer to wire it by hand? Everything the prompt references is spelled out in the sections below.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # 🐻 Bearound React Native SDK
 
 Official SDK to integrate **Bearound's** secure BLE beacon detection into **React Native** apps (Android and iOS).
-Aligned with Bearound native SDKs **3.4.2** (exact pins live in `android/build.gradle` and `BearoundReactSdk.podspec`, kept in lockstep by `scripts/check-native-versions.mjs`).
+Aligned with Bearound native SDKs **3.4.5** (exact pins live in `android/build.gradle` and `BearoundReactSdk.podspec`, kept in lockstep by `scripts/check-native-versions.mjs`).
 
 > ✅ Compatible with **New Architecture** (TurboModules) and also compatible with classic architecture.
+
+> [!TIP]
+> **⚡ Set it up with an AI agent.** Don't wire the iOS/Android background integration by hand — hand [one prompt](./AI-AGENT-SETUP.md) to your AI coding agent (Claude Code, Cursor, Copilot) and let it pilot the whole install, pausing only for the few human-only steps. → [Set up with an AI agent](#set-up-with-an-ai-agent)
+
+[![Agent setup prompt](https://img.shields.io/badge/Agent_setup_prompt-open_%26_copy-2563eb?style=for-the-badge)](./AI-AGENT-SETUP.md)
 
 ---
 
@@ -239,7 +244,7 @@ This section is the **consumer contract** for background and terminated-state op
 
 The snippets below are the example app **verbatim**: §1 is the **complete** `AppDelegate` and §2 + the usage-description strings in [Permission Configuration → iOS](#ios--infoplist-and-background-modes) together form the **complete** `Info.plist`. Copy them as-is (changing only the module name, marked in §1).
 
-> **Template note:** §1 is the **Swift** `AppDelegate` (the React Native ≥ 0.77 default — `RCTReactNativeFactory` / `ReactNativeDelegate`). If your app still ships the older Objective-C `AppDelegate.mm` (common on RN 0.73–0.76), wire the **same** calls there instead, or migrate the target to the Swift template first (add a bridging header if needed).
+> **Template note:** §1 is the **Swift** `AppDelegate` (the React Native ≥ 0.77 default — `RCTReactNativeFactory` / `ReactNativeDelegate`). `BeAroundSDK` is a **pure-Swift** API (not `@objc`), so it **cannot be called from an Objective-C `AppDelegate.mm`**. If your app still ships `AppDelegate.mm` (common on RN 0.73–0.76), you must **migrate the target to a Swift `AppDelegate`** and wire the calls there — on RN 0.73–0.76 that's a Swift `AppDelegate` subclassing `RCTAppDelegate`; on ≥ 0.77 it's the `RCTReactNativeFactory` template above. A bridging header (Objective-C → Swift) does not help here.
 
 ### 1. AppDelegate wiring
 

--- a/README.md
+++ b/README.md
@@ -76,51 +76,11 @@ No additional Gradle configuration is needed beyond permissions. The native Andr
 
 ## Set up with an AI agent
 
-The iOS/Android background wiring is intricate — but this README is written to be **agent-readable**: every step is explicit, copy-pasteable, and tied to the proven-working example. So instead of doing it by hand, you can hand the whole thing to an **AI coding agent** (Claude Code, Cursor, Copilot, …) and have it do the integration for you.
+Instead of wiring the intricate iOS/Android background setup by hand, hand it to an **AI coding agent** (Claude Code, Cursor, Copilot, …). This README is written to be **agent-readable** — the agent reads it and does the whole integration. There's one ready-made prompt to give it:
 
-**Point your agent at this README** — the local copy at `node_modules/@bearound/react-native-sdk/README.md` or the [GitHub page](https://github.com/Bearound/bearound-react-native-sdk) — and paste this prompt:
+[![Agent setup prompt](https://img.shields.io/badge/Agent_setup_prompt-open_%26_copy-2563eb?style=for-the-badge)](./AI-AGENT-SETUP.md)
 
-```text
-Integrate @bearound/react-native-sdk into this React Native app. First READ the
-SDK's README end to end — especially "iOS Background Integration (required)",
-"Permission Configuration", and "Quick Start" — then do ALL of the following,
-matching the README's proven-working example EXACTLY:
-
-1. Install: `npm i @bearound/react-native-sdk`, then `cd ios && pod install`.
-
-2. iOS AppDelegate (§1): wire the COMPLETE AppDelegate from README §1 into this
-   app's AppDelegate — EVERY method, none optional: the SDK delegate,
-   registerBackgroundTasks, the UNUserNotificationCenter delegate +
-   requestAuthorization, application.registerForRemoteNotifications(),
-   launchOptions handling, performFetch,
-   didRegisterForRemoteNotificationsWithDeviceToken -> setPushToken,
-   didFailToRegister, the `bearound` silent-push handler,
-   handleEventsForBackgroundURLSession, and willPresent. Use THIS app's own
-   registered module name in startReactNative (do NOT leave the placeholder).
-   If the app still ships the Objective-C AppDelegate.mm, port the same calls there.
-
-3. iOS Info.plist: add the five UIBackgroundModes, the two
-   BGTaskSchedulerPermittedIdentifiers (io.bearound.sdk.sync,
-   io.bearound.sdk.processing), and the four NS…UsageDescription strings — write
-   a user-facing rationale that matches what THIS app actually does (no internal
-   jargon). Then run `plutil -lint` and confirm it prints OK.
-
-4. JS (§4 / Quick Start): call configure({ businessToken: <ASK ME FOR IT> }) on
-   root-component mount (useEffect), then startScanning(); on Android also call
-   enableForegroundScanning() after startScanning().
-
-5. Verify (§6): run the plutil checks and give me the 3-state field-test checklist
-   (foreground / background / terminated).
-
-Guardrails — follow strictly:
-- NEVER rely on the push swizzle alone; forward the RAW APNs token explicitly.
-- The SDK must NEVER crash the host app.
-- Ask me for my businessToken; do not invent one.
-- STOP and hand me click-by-click steps for anything only a human can do (below).
-  Do not attempt those yourself.
-```
-
-> **Grab it in one click.** On GitHub, hover the block above and click the **copy icon** in its top-right corner. Prefer a link? Open [`AI-AGENT-SETUP.md`](./AI-AGENT-SETUP.md) — the same prompt on its own page — or point a web-capable agent straight at its [raw URL](https://raw.githubusercontent.com/Bearound/bearound-react-native-sdk/main/AI-AGENT-SETUP.md).
+Open [`AI-AGENT-SETUP.md`](./AI-AGENT-SETUP.md) and click the **copy icon** on its code block — GitHub shows one on every code block, and it drops the prompt on your clipboard. Then paste it into your agent with your app's repo open. Web-capable agents can fetch its [raw URL](https://raw.githubusercontent.com/Bearound/bearound-react-native-sdk/main/AI-AGENT-SETUP.md) directly.
 
 **The agent will pause for these human-only steps** — they need your Apple/Google accounts and a physical device, so no SDK or agent can do them:
 


### PR DESCRIPTION

**O que tem aqui:**
- **Seção "Set up with an AI agent"** no README — um prompt pronto que o integrador cola no agente dele (Claude Code, Cursor, Copilot) e o agente faz a integração iOS/Android inteira, com os guardrails que aprendemos na marra (nunca confiar só no swizzle, module name real, nunca crashar o host, pedir o businessToken) + os passos human-only (capability de Push, permissões no device, foreground service no Play).
- **`AI-AGENT-SETUP.md`** — o mesmo prompt numa página própria. Serve de alvo de cópia (o GitHub renderiza o **botão de copiar** no bloco de código) e de **URL raw** pra um agente com acesso à web buscar direto.
- **Nota de copy** na seção apontando pro ícone nativo do GitHub + o link do arquivo.

**Por que não um botão JS:** README é markdown sanitizado — não dá pra ter um botão de `copy to clipboard` próprio. A solução é o botão nativo do GitHub (todo bloco de código já tem) + o fallback via link.

Docs-only. Seguimos no **3.4.5**, sem bump.