### PR TITLE
chore(ci): remove Codecov

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -40,14 +40,6 @@ jobs:
       - name: Run unit tests
         run: yarn test --maxWorkers=2 --coverage
 
-      - name: Upload coverage to Codecov
-        if: success()
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          verbose: true
-
       - name: Test coverage check
         run: |
           echo "Checking test coverage results..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,6 @@ jobs:
       - name: Run unit tests
         run: yarn test --maxWorkers=2 --coverage
 
-      - name: Upload coverage to Codecov
-        if: success()
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          verbose: true
-
       - name: Test coverage check
         run: |
           echo "Checking test coverage results..."


### PR DESCRIPTION
Remove o **Codecov** dos 2 workflows de CI (o step `Upload coverage to Codecov`). Sem mais comentário do bot codecov nos PRs nem gating de cobertura por serviço externo. O Jest continua rodando com `--coverage` local — só paramos de enviar pro codecov.io. CI-only, sem mudança de código do SDK.