### PR TITLE
feat(push): expõe handleRemoteMessage no bridge (silent-push wake-up Android)

### DIFF
--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -71,7 +71,19 @@ is more specific, it wins.
    ensurePermissions — without it, iOS is foreground-only and Android 12+ detects
    NOTHING.
 
-5. Verify: run `plutil -lint` / `plutil -p` (all five modes + both BGTask ids), and in
+5. Silent-push wake-up on Android (OPTIONAL — do this ONLY if the backend wakes the
+   device by push; skip it otherwise). If the app uses `@react-native-firebase/messaging`,
+   register at module scope (before `AppRegistry.registerComponent`)
+   `messaging().setBackgroundMessageHandler(async (msg) => { await handleRemoteMessage(msg.data); })`
+   and import `handleRemoteMessage` from `@bearound/react-native-sdk` — it resolves `true`
+   for a Bearound wake (payload marked `bearound`) and `false` for third-party pushes, so
+   forward EVERY data message and pass the non-Bearound ones through to your own handling.
+   iOS needs none of this here — the step-2 AppDelegate already covers it via the same
+   silent-push path. If the app does NOT use @react-native-firebase, instead register
+   `io.bearound.sdk.push.BearoundMessagingService` in the app's AndroidManifest.xml (see
+   README → "Silent-push wake-up (Android)").
+
+6. Verify: run `plutil -lint` / `plutil -p` (all five modes + both BGTask ids), and in
    code confirm the JS actually wires ensurePermissions() /
    requestLocationAuthorization('always') and gates startScanning() on the grant. Then
    BUILD iOS and confirm it COMPILES —

--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -79,9 +79,12 @@ is more specific, it wins.
    for a Bearound wake (payload marked `bearound`) and `false` for third-party pushes, so
    forward EVERY data message and pass the non-Bearound ones through to your own handling.
    iOS needs none of this here — the step-2 AppDelegate already covers it via the same
-   silent-push path. If the app does NOT use @react-native-firebase, instead register
-   `io.bearound.sdk.push.BearoundMessagingService` in the app's AndroidManifest.xml (see
-   README → "Silent-push wake-up (Android)").
+   silent-push path. If the app does NOT use @react-native-firebase but DOES bundle native
+   Firebase (google-services plugin configured), instead register
+   `io.bearound.sdk.push.BearoundMessagingService` in the app's AndroidManifest.xml — the
+   class ships inside the native Android SDK the wrapper embeds. With no Firebase in the
+   app at all there is nothing to wire: FCM does the delivering, so push wake-up is
+   inapplicable.
 
 6. Verify: run `plutil -lint` / `plutil -p` (all five modes + both BGTask ids), and in
    code confirm the JS actually wires ensurePermissions() /

--- a/README.md
+++ b/README.md
@@ -236,6 +236,25 @@ await enableForegroundScanning();
 
 The SDK doesn't bundle WorkManager. For a predictable low-frequency sweep without a foreground service, schedule your own periodic worker (minimum interval **15 min**) that calls `startScanning()` for a short window and then `stopScanning()`. Trades latency for battery and avoids the Play video — presence lags by up to the chosen period.
 
+### Silent-push wake-up (Android)
+
+A **silent FCM data message** can wake a killed or backgrounded app to restart the scan and sync immediately — the Android counterpart to the iOS silent-push wake vector. Forward the message to the SDK from your Firebase background handler:
+
+```ts
+// index.js — registered at module scope, before AppRegistry.registerComponent.
+import messaging from '@react-native-firebase/messaging';
+import { handleRemoteMessage } from '@bearound/react-native-sdk';
+
+// Runs in a headless JS task when a data message arrives with the app in
+// background or killed. Forward the payload; the SDK restarts the scan + syncs
+// when it recognizes a Bearound wake and resolves `true`.
+messaging().setBackgroundMessageHandler(async (remoteMessage) => {
+  await handleRemoteMessage(remoteMessage.data);
+});
+```
+
+Requires `@react-native-firebase/messaging` and a **data** message (not notification-only, which the OS delivers to the tray without waking JS). **iOS needs none of this** — the silent push is handled by the AppDelegate wiring in [iOS Background Integration](#ios-background-integration-required); calling `handleRemoteMessage` there simply resolves `false` for any non-Bearound payload.
+
 ---
 
 ## iOS Background Integration (required)
@@ -739,6 +758,13 @@ clearUserProperties(): Promise<void>;
 //   BearoundAppDelegateProxyEnabled = NO. See "Using Firebase Messaging /
 //   disabled swizzling?" above.
 setPushToken(token: string): Promise<void>;
+
+// Silent-push wake-up (Android). Forward an FCM data-message payload
+// (remoteMessage.data) from your Firebase setBackgroundMessageHandler to restart
+// the scan + sync; resolves true when the SDK recognizes a Bearound wake. On iOS
+// the AppDelegate handles the silent push and this resolves false for
+// non-Bearound payloads. See "Silent-push wake-up (Android)" under Scan modes.
+handleRemoteMessage(data: { [key: string]: string }): Promise<boolean>;
 
 // Error telemetry opt-out (default: enabled). See "SDK error telemetry" below.
 setErrorReportingEnabled(enabled: boolean): void;

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -218,6 +218,23 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     }
   }
 
+  // Silent-push wake-up: forward an FCM data-message payload to the native SDK,
+  // which restarts the scan + syncs when it recognizes a Bearound wake.
+  // Resolves the SDK's handled flag. Same `sdk` instance as setPushToken.
+  override fun handleRemoteMessage(data: ReadableMap, promise: Promise) {
+    try {
+      val map = HashMap<String, String>()
+      val iterator = data.keySetIterator()
+      while (iterator.hasNextKey()) {
+        val key = iterator.nextKey()
+        map[key] = data.getString(key) ?: ""
+      }
+      promise.resolve(sdk.handleRemoteMessage(map))
+    } catch (t: Throwable) {
+      promise.reject("HANDLE_REMOTE_MESSAGE_ERROR", t)
+    }
+  }
+
   override fun checkPermissions(promise: Promise) {
     promise.resolve(true)
   }

--- a/ios/BearoundReactSdk.mm
+++ b/ios/BearoundReactSdk.mm
@@ -211,6 +211,19 @@ maxQueuedPayloads:(double)maxQueuedPayloads
   resolve(nil);
 }
 
+// Forwards an FCM data-message payload to the native SDK to trigger the
+// silent-push background wake-up (restart scan + sync). Resolves YES when the
+// SDK handled it. Android-only in practice; on iOS the AppDelegate handles the
+// silent push and RNBearoundBridge resolves NO for non-bearound payloads.
+- (void)handleRemoteMessage:(NSDictionary *)data
+                    resolve:(RCTPromiseResolveBlock)resolve
+                     reject:(RCTPromiseRejectBlock)reject
+{
+  NSDictionary *payload = data ?: @{};
+  BOOL handled = [[RNBearoundBridge shared] handleRemoteMessage:payload];
+  resolve(@(handled));
+}
+
 - (void)isIgnoringBatteryOptimizations:(RCTPromiseResolveBlock)resolve
                                 reject:(RCTPromiseRejectBlock)reject
 {

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -246,6 +246,21 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
     }
   }
 
+  // Silent-push wake-up. On iOS the AppDelegate already handles the `bearound`
+  // silent push directly, so this exists mainly for cross-platform parity with
+  // Android: it triggers the same background BLE refresh + sync when the payload
+  // is a Bearound wake, and ignores anything else.
+  public func handleRemoteMessage(_ data: [String: Any]) -> Bool {
+    guard data["bearound"] != nil else { return false }
+    DispatchQueue.main.async {
+      self.sdk.performBackgroundBLERefreshAndSync(
+        bleScanDuration: 10,
+        trigger: "silent_push"
+      ) { _ in }
+    }
+    return true
+  }
+
   public func checkPermissions() -> Bool {
     let status = currentAuthorizationStatus()
     return status == .authorizedAlways || status == .authorizedWhenInUse

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -19,6 +19,12 @@ export interface Spec extends TurboModule {
   // which associates it with the stable deviceId and sends it on the next sync.
   setPushToken(token: string): Promise<void>;
 
+  // Silent-push wake-up. Forwards an FCM data-message payload to the native SDK,
+  // which restarts the scan and syncs when it recognizes a Bearound wake. Returns
+  // true when handled. Android-only in practice; on iOS the AppDelegate handles
+  // the silent push and this resolves false for non-Bearound payloads.
+  handleRemoteMessage(data: Object): Promise<boolean>;
+
   checkPermissions(): Promise<boolean>;
   requestPermissions(): Promise<boolean>;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -459,6 +459,23 @@ export async function setPushToken(token: string): Promise<void> {
   await Native.setPushToken(token);
 }
 
+/**
+ * Forwards an FCM **data message** payload to the native SDK to trigger the
+ * silent-push background wake-up (restart scan + sync). Resolves `true` when the
+ * SDK recognized and handled the message.
+ *
+ * **Android-only.** Call it from your `@react-native-firebase/messaging`
+ * `setBackgroundMessageHandler` with `remoteMessage.data` (it runs in a headless
+ * JS task). On iOS the silent push is handled by the AppDelegate wiring (see
+ * "iOS Background Integration" in the README) — there this resolves `false` for
+ * any non-Bearound payload.
+ */
+export async function handleRemoteMessage(data: {
+  [key: string]: string;
+}): Promise<boolean> {
+  return Native.handleRemoteMessage(data);
+}
+
 // --- Diagnostic / state accessors (parity with native public API) ---
 
 export type AuthorizationStatus =


### PR DESCRIPTION
## O quê

Expõe `handleRemoteMessage(data)` no bridge do SDK React Native, permitindo que um app RN encaminhe um **FCM data message** pro SDK e acione o **silent-push wake-up** no Android (no wake o nativo reinicia o scan + sincroniza).

Adiciona o método em todas as camadas, **espelhando o `setPushToken` existente**:

| Camada | Arquivo |
|---|---|
| Spec TurboModule | `src/NativeBearoundReactSdk.ts` — `handleRemoteMessage(data: Object): Promise<boolean>` |
| JS | `src/index.tsx` — `export async function handleRemoteMessage(data)` |
| Android | `BearoundReactSdkModule.kt` — converte `ReadableMap`→`Map<String,String>` e delega p/ `sdk.handleRemoteMessage(map)` |
| iOS (.mm) | `BearoundReactSdk.mm` — recebe `NSDictionary`, resolve `BOOL` |
| iOS (Swift) | `RNBearoundBridge.swift` — delega p/ `performBackgroundBLERefreshAndSync(trigger:"silent_push")` |
| Doc | `README.md` — subseção "Silent-push wake-up (Android)" + entrada na API |

## Como usar (caminho B — encaminhar do `@react-native-firebase/messaging`)

```ts
import messaging from '@react-native-firebase/messaging';
import { handleRemoteMessage } from '@bearound/react-native-sdk';

messaging().setBackgroundMessageHandler(async (remoteMessage) => {
  await handleRemoteMessage(remoteMessage.data);
});
```

Roda num **headless JS task** quando o data message chega com o app em background/morto. No **iOS** nada disso é necessário — o `AppDelegate` já trata o silent push; `handleRemoteMessage` resolve `false` p/ payload não-`bearound`.

## Dependência

⚠️ **DEPENDE do `bearound-android-sdk` #60 publicado** (`BeAroundSDK.handleRemoteMessage(Map): Boolean`). Enquanto o release nativo com esse método não estiver no JitPack, o **compile/CI Android fica vermelho com `unresolved reference` — isso é esperado**, não é erro deste bridge.

## Validação

- `npx tsc --noEmit` — sem erros
- `node scripts/check-native-versions.mjs` — alinhado (native 3.4.5, RN major 3)
- `npx jest` — 148/148 passam
- eslint — limpo
- CI Android — vermelho até o #60 publicar (esperado, ver acima)

## Não mergear

Bloqueado pela publicação do `bearound-android-sdk` #60.
