### PR TITLE
release: 3.5.0 — embrulha nativo 3.5.0 (fix scan BLE + silent-push)

### DIFF
--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.4.5"
+  s.dependency "BearoundSDK", "3.5.0"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-07-14
+
+### Added
+
+- **Silent-push wake-up bridge (Android):** new `handleRemoteMessage(data)` — forward the FCM data message from your `@react-native-firebase/messaging` background handler and the SDK triggers an on-demand scan + sync (resolves `true` only for Bearound wake-ups, marked `bearound`). See README → *Silent-push wake-up (Android)*.
+
+### Changed
+
+- Wraps native **iOS 3.5.0** (BLE scan fix: `withServices: nil` + Service Data `0xBEAD` match — beacons detect again; regression since 2.3.2) and **Android v3.5.0** (silent-push wake-up + never-crash-the-host hardening).
+
 ## [3.4.5] - 2026-07-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🐻 Bearound React Native SDK
 
 Official SDK to integrate **Bearound's** secure BLE beacon detection into **React Native** apps (Android and iOS).
-Aligned with Bearound native SDKs **3.4.5** (exact pins live in `android/build.gradle` and `BearoundReactSdk.podspec`, kept in lockstep by `scripts/check-native-versions.mjs`).
+Aligned with Bearound native SDKs **3.5.0** (exact pins live in `android/build.gradle` and `BearoundReactSdk.podspec`, kept in lockstep by `scripts/check-native-versions.mjs`).
 
 > ✅ Compatible with **New Architecture** (TurboModules) and also compatible with classic architecture.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,8 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   // Exact pin, kept in lockstep with the iOS podspec dep (same native release).
-  // 3.4.5 fixes the FGS connectedDevice crash-loop and adds the battery-opt/OEM
-  // autostart reliability helpers exposed by the RN bridge.
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.4.5'
+  // v3.5.0 adds the silent-push wake-up (handleRemoteMessage + BearoundMessagingService)
+  // and the never-crash-the-host hardening, on top of the 3.4.x line (FGS crash fixes,
+  // battery-opt/OEM autostart reliability helpers exposed by the RN bridge).
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.5.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.4.5",
+  "version": "3.5.0",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
Bump pra **3.5.0**, embrulhando iOS 3.5.0 + Android v3.5.0 (guard de lockstep ✅). Ordem: (1) merge quando o CI ficar verde (pods/JitPack 3.5.0 publicando); (2) rebase + merge do #24 (bridge handleRemoteMessage); (3) tag `v3.5.0` → ci-cd publica no npm. Substitui o #23 (3.4.6, fechado).