### PR TITLE
chore: bump android native sdk to v3.5.1

### DIFF
--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.5.0"
+  s.dependency "BearoundSDK", "3.5.1"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2026-07-22
+
+### Changed
+
+- **Android native SDK v3.5.0 → v3.5.1.** Scan reliability on modern Android 13+ (periodic anti-downgrade scan refresh, batch-scan filter for pure-0xBEAD frames from firmware v4 beacons, PendingIntent scan kept armed in foreground), ghost-beacon fixes on the host list (expirations now reach the listener, including the empty list) and scan-precision changes now apply immediately on reconfigure. No JS API changes — all fixes live in the embedded native SDK. See the native SDK CHANGELOG for full details.
+
 ## [3.5.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.5.1] - 2026-07-22
+## [3.5.2] - 2026-07-22
 
 ### Changed
 
+- **Android native SDK v3.5.0 → v3.5.2** (3.5.1 was never published for this wrapper; this release carries both). Scan reliability on modern Android 13+ (anti-downgrade refresh, pure-0xBEAD batch filter, PendingIntent kept armed in foreground), **continuous hardware-managed duty for MEDIUM/LOW** (no more scan-start-quota starvation), **adaptive foreground boost** (LOW_LATENCY whenever the app is in use — best detection automatically with the MEDIUM default), smooth beacon presence (10 s stale fade / 15 s eviction), **weak-receiver SoC profile** (Unisoc/Spreadtrum devices get doubled retention windows automatically), ghost-beacon fixes and precision-apply fix.
+- Native version alignment check now requires the same **MAJOR.MINOR line** (patch may differ): platform-specific patches ship independently and the exact-pin rule forced an empty alignment release of the other platform for every patch.
 - **Android native SDK v3.5.0 → v3.5.1.** Scan reliability on modern Android 13+ (periodic anti-downgrade scan refresh, batch-scan filter for pure-0xBEAD frames from firmware v4 beacons, PendingIntent scan kept armed in foreground), ghost-beacon fixes on the host list (expirations now reach the listener, including the empty list) and scan-precision changes now apply immediately on reconfigure. No JS API changes — all fixes live in the embedded native SDK. See the native SDK CHANGELOG for full details.
 
 ## [3.5.0] - 2026-07-14

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.5.0 adds the silent-push wake-up (handleRemoteMessage + BearoundMessagingService)
   // and the never-crash-the-host hardening, on top of the 3.4.x line (FGS crash fixes,
   // battery-opt/OEM autostart reliability helpers exposed by the RN bridge).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.5.0'
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.5.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.5.0 adds the silent-push wake-up (handleRemoteMessage + BearoundMessagingService)
   // and the never-crash-the-host hardening, on top of the 3.4.x line (FGS crash fixes,
   // battery-opt/OEM autostart reliability helpers exposed by the RN bridge).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.5.1'
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.5.2'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/scripts/check-native-versions.mjs
+++ b/scripts/check-native-versions.mjs
@@ -45,12 +45,22 @@ if ([pkgMajor, iosMajor, androidMajor].some((m) => Number.isNaN(m))) {
   process.exit(1);
 }
 
-// 1) iOS and Android must point to the SAME native release (both pinned exact).
-if (iosVersion !== androidVersion) {
+const lineOf = (version) => {
+  const m = String(version).match(/(\d+)\.(\d+)/);
+  return m ? `${m[1]}.${m[2]}` : null;
+};
+
+// 1) iOS and Android must sit on the SAME native MINOR line (MAJOR.MINOR); the patch
+//    digit may differ. Platform-specific patches ship independently (e.g. Android-only
+//    scan-reliability fixes in 3.5.1/3.5.2), and the previous exact-pin rule forced an
+//    EMPTY alignment release of the other platform for every such patch — twice in two
+//    days. Same-line keeps the real guard (feature parity per MINOR) without the
+//    empty-release tax.
+if (lineOf(iosVersion) !== lineOf(androidVersion)) {
   console.error(
-    `\n❌ Native dep mismatch. iOS BearoundSDK (${iosVersion}) and Android ` +
-      `bearound-android-sdk (${androidVersion}) must pin the exact same native release.\n` +
-      `   Bump both in lockstep when a new native version ships.`
+    `\n❌ Native line mismatch. iOS BearoundSDK (${iosVersion}) and Android ` +
+      `bearound-android-sdk (${androidVersion}) must be on the same MAJOR.MINOR line.\n` +
+      `   Bump the lagging platform to the current line.`
   );
   process.exit(1);
 }
@@ -65,5 +75,5 @@ if (iosMajor !== pkgMajor) {
 }
 
 console.log(
-  `\n✅ Aligned: native ${iosVersion} on both platforms; RN major ${pkgMajor} mirrors native major ${iosMajor}.`
+  `\n✅ Aligned: native line ${lineOf(iosVersion)} (iOS ${iosVersion} / Android ${androidVersion}); RN major ${pkgMajor} mirrors native major ${iosMajor}.`
 );


### PR DESCRIPTION
Bump do SDK Android nativo embarcado: `v3.5.0 → v3.5.1` (pin no `android/build.gradle`) + versão do pacote `3.5.1` + CHANGELOG.

**O que vem no 3.5.1 nativo** (validado em bancada, realme C61/Android 14): confiabilidade de scan no Android 13+ (refresh anti-downgrade de 20 min, filtro de batch para frames 0xBEAD puros do firmware v4, PendingIntent armado em foreground), correção dos beacons fantasma na lista do listener e do precision que não aplicava na reconfiguração. **Zero mudança de código JS.**

Pós-merge: tag `v3.5.1` → npm (fluxo de sempre).