### PR TITLE
chore: bump native sdks to the 3.6 line (ios 3.6.2, android v3.6.1)

### DIFF
--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.5.1"
+  s.dependency "BearoundSDK", "3.6.2"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.2] - 2026-07-25
+
+### Changed
+
+- **Native SDKs bumped to the 3.6 line** — iOS `BearoundSDK` 3.6.2 and Android `bearound-android-sdk` v3.6.1, carrying the full background/reliability package:
+  - **iOS — background detection unlocked**: state-dependent BLE scan filter (`nil` foreground / `0xBEAD` background, pairs with beacon firmware v6) plus presence integrity — kernel region exits are confirmed before being propagated (no more false "left the zone" while parked next to a beacon), `CLRegionState.unknown` is preserved, cold relaunches survive until the region state resolves, and the Location-only permission profile (no Bluetooth) now detects and syncs end-to-end.
+  - **iOS — coordinated sync**: single funnel for all triggers, detection-driven uploads (~seconds after entering a zone), 5 s foreground fast-path for changed samples, 1 s background batch window, and a 60 s per-beacon re-report that cuts steady-state volume ~4× without changing the ingest contract.
+  - **iOS — device floor back to iOS 15** and honest platform-guarantees documentation.
+  - **Android — ghost-beacon fixes**: controller "fossil replay" guard (MediaTek batch-buffer re-delivery), zombie synced-card release, and a periodic scan watchdog that keeps recovering the scan instead of dying with it.
+
 ## [3.5.2] - 2026-07-22
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.5.0 adds the silent-push wake-up (handleRemoteMessage + BearoundMessagingService)
   // and the never-crash-the-host hardening, on top of the 3.4.x line (FGS crash fixes,
   // battery-opt/OEM autostart reliability helpers exposed by the RN bridge).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.5.2'
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.6.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.5.2",
+  "version": "3.6.2",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
Replica no wrapper React Native o pacote de background/confiabilidade dos nativos. Mesmo conteúdo do PR gêmeo do Flutter.

## Pins
| Nativo | De | Para |
|---|---|---|
| iOS `BearoundSDK` | 3.5.1 | **3.6.2** |
| Android `bearound-android-sdk` | v3.5.2 | **v3.6.1** |

Wrapper: **3.6.2**. `check-native-versions` ✅ (linha 3.6 alinhada; RN major 3 = nativo major 3).

## O que os apps RN ganham
- **iOS detectando em background** (filtro dinâmico — par do firmware v6) com **presença íntegra**: exits do kernel confirmados antes de propagar, `unknown` preservado, relaunch de terminado estável, e o perfil **Location-only** sincando fim-a-fim.
- **Sync coordenado**: upload em ~segundos após a detecção, fast-path 5 s, batch bg 1 s, re-report 60 s/beacon (volume ~4× menor).
- **iOS 15 de volta ao piso** de devices.
- **Android sem beacons fantasma**: guard anti-replay (MediaTek), card zumbi liberado, watchdog periódico.

## Integração
O example já faz o toque crítico no AppDelegate (`BeAroundSDK.shared` + delegate + `registerBackgroundTasks()` antes do bridge) — nenhuma mudança de API pública.

## Passou se
- `pod install` resolve 3.6.2 (CDN ~30 min pós-trunk) e o Gradle resolve v3.6.1 no JitPack.
- Example iOS em bg com beacon v6 pulsando no monitor; example Android MediaTek sem fantasma.