### PR TITLE
iOS debug bench notifications + example bundle under io.bearound

### DIFF
--- a/example/ios/BearoundReactSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/BearoundReactSdkExample.xcodeproj/project.pbxproj
@@ -257,12 +257,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3B4392A12AC88292D35C810B /* Pods-BearoundReactSdkExample.debug.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = BearoundReactSdkExample/BearoundReactSdkExample.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2F225FWN5Q;
 				ENABLE_BITCODE = NO;
-				CODE_SIGN_ENTITLEMENTS = BearoundReactSdkExample/BearoundReactSdkExample.entitlements;
 				INFOPLIST_FILE = BearoundReactSdkExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -275,7 +276,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = bearoundreactsdk.example;
+				PRODUCT_BUNDLE_IDENTIFIER = io.bearound.rnScanExample;
 				PRODUCT_NAME = BearoundReactSdkExample;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -287,11 +288,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5709B34CF0A7D63546082F79 /* Pods-BearoundReactSdkExample.release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = BearoundReactSdkExample/BearoundReactSdkExample.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2F225FWN5Q;
-				CODE_SIGN_ENTITLEMENTS = BearoundReactSdkExample/BearoundReactSdkExample.entitlements;
 				INFOPLIST_FILE = BearoundReactSdkExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -304,7 +306,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = bearoundreactsdk.example;
+				PRODUCT_BUNDLE_IDENTIFIER = io.bearound.rnScanExample;
 				PRODUCT_NAME = BearoundReactSdkExample;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/example/ios/BearoundReactSdkExample/AppDelegate.swift
+++ b/example/ios/BearoundReactSdkExample/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // log + local notification never happen. Doing this via the async JS
     // configure() path is too late and races the relaunch region event.
     BeAroundSDK.shared.delegate = RNBearoundBridge.shared
+    RNBearoundBridge.shared.debugNotificationsEnabled = true
 
     // Register background tasks BEFORE app finishes launching
     BeAroundSDK.shared.registerBackgroundTasks()

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -7,6 +7,27 @@ import BearoundSDK
 @objcMembers
 @objc(RNBearoundBridge)
 public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralManagerDelegate, BeAroundSDKDelegate {
+
+  // MARK: - Bench notifications (native-example parity; QA aid)
+  // Same texts/cooldowns as the native BeAroundScan example so side-by-side
+  // background tests read identically on both lock screens.
+  /// Off by default; the bundled example turns it on from its AppDelegate.
+  /// Production hosts never see these notifications.
+  public var debugNotificationsEnabled = false
+  private var debugNotifyLast: [String: Date] = [:]
+  private func debugNotify(id: String, title: String, body: String, cooldown: TimeInterval) {
+    guard debugNotificationsEnabled else { return }
+    if let last = debugNotifyLast[id], Date().timeIntervalSince(last) < cooldown { return }
+    debugNotifyLast[id] = Date()
+    let content = UNMutableNotificationContent()
+    content.title = title
+    content.body = body
+    content.sound = .default
+    UNUserNotificationCenter.current().add(
+      UNNotificationRequest(identifier: "bearound.debug.\(id).\(Int(Date().timeIntervalSince1970))",
+                            content: content, trigger: nil))
+  }
+
   @objc public static let shared = RNBearoundBridge()
   private lazy var sdk: BeAroundSDK = {
     if Thread.isMainThread {
@@ -403,6 +424,11 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
   }
   
   public func didCompleteSync(beaconCount: Int, success: Bool, error: Error?) {
+    debugNotify(id: "sync",
+                title: success ? "Sync Completo" : "Sync Falhou",
+                body: success ? "Enviado\(beaconCount == 1 ? "" : "s") \(beaconCount) beacon\(beaconCount == 1 ? "" : "s") para o servidor"
+                              : (error?.localizedDescription ?? "erro desconhecido"),
+                cooldown: 5)
     let payload: [String: Any] = [
       "type": "completed",
       "beaconCount": beaconCount,
@@ -419,6 +445,9 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
   // v3.0: native changed the signature from (beaconCount: Int) to (beacons: [Beacon]).
   // The JS event keeps the {beaconCount} shape for cross-platform parity with Android.
   public func didDetectBeaconInBackground(beacons: [Beacon]) {
+    debugNotify(id: "bg-detect", title: "Beacon Detectado (Background)",
+                body: "Encontrado \(beacons.count) beacon\(beacons.count == 1 ? "" : "s") próximo\(beacons.count == 1 ? "" : "s")",
+                cooldown: 5)
     let payload: [String: Any] = [
       "beaconCount": beacons.count
     ]
@@ -431,12 +460,16 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
   // v2.5 — Beacon region lifecycle (bridge only forwards the event; host app owns any notification).
 
   public func didEnterBeaconRegion() {
+    debugNotify(id: "zone-enter", title: "Entrou na zona",
+                body: "Bearound detectou uma região de beacons (Location)", cooldown: 10)
     DispatchQueue.main.async {
       BearoundReactSdkEventEmitter.emit("bearound:beaconRegion", body: ["type": "enter"])
     }
   }
 
   public func didExitBeaconRegion() {
+    debugNotify(id: "zone-exit", title: "Saiu da zona",
+                body: "Bearound: você saiu da região de beacons (Location)", cooldown: 10)
     DispatchQueue.main.async {
       BearoundReactSdkEventEmitter.emit("bearound:beaconRegion", body: ["type": "exit"])
     }
@@ -451,12 +484,16 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
   // v2.5 — Bluetooth "two eyes" zone (iOS-only; Android has no equivalent).
 
   public func didEnterBluetoothZone() {
+    debugNotify(id: "bt-zone-enter", title: "Entrou na zona",
+                body: "Bearound detectou uma região de beacons (Bluetooth)", cooldown: 10)
     DispatchQueue.main.async {
       BearoundReactSdkEventEmitter.emit("bearound:bluetoothZone", body: ["type": "enter"])
     }
   }
 
   public func didExitBluetoothZone() {
+    debugNotify(id: "bt-zone-exit", title: "Saiu da zona",
+                body: "Bearound: você saiu da região de beacons (Bluetooth)", cooldown: 10)
     DispatchQueue.main.async {
       BearoundReactSdkEventEmitter.emit("bearound:bluetoothZone", body: ["type": "exit"])
     }


### PR DESCRIPTION
## What

- New `RNBearoundBridge.debugNotificationsEnabled` property (**default `false`**). When a host opts in, the bridge posts the same local notifications as the native scan example — zone enter/exit (Location and Bluetooth), background detection, sync success/failure — with matching cooldowns (10s zone, 5s detect/sync). No change to the JS contract.
- Example app opts in from its AppDelegate and moves its bundle to `io.bearound.rnScanExample` (automatic signing).

## Why

- Field QA compares the RN wrapper against the native example on the lock screen; without these notifications the RN run was silent and unverifiable at a glance.
- The old `bearoundreactsdk.example` bundle predates the io.bearound naming used by the other SDK examples; the new bundle keeps APNs push tests consistent across the fleet.

## Passed if

- Default (flag off): zero notifications — production hosts unaffected.
- Example build: lock-screen notifications identical to the native example during the same test run.

Validated on a bench iPhone 16 Pro Max: silent push → scan → sync end to end, notifications side by side with native.