### PR TITLE
feat: real detection log on Android + per-minute view (iOS parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Real persisted detection log on Android** — `getPersistedLog()` / `clearPersistedLog()` now forward to the native Android SDK v3.7.0 (`getDetectionLogJson()` / `clearDetectionLog()`) instead of resolving a hardcoded `[]`. The log is disk-persisted (SharedPreferences) and each entry is tagged with the app state at write time — `foreground`, `background`, `backgroundLocked` or `terminated` — so the example's Log screen finally shows what the SDK did while the app was closed, on both platforms with the same entry vocabulary (`Scan`, `Background`, `Região`, `Sync OK`, `Sync falhou`).
+- **Real persisted detection log on Android** — `getPersistedLog()` / `clearPersistedLog()` now forward to the native Android SDK v3.6.2 (`getDetectionLogJson()` / `clearDetectionLog()`) instead of resolving a hardcoded `[]`. The log is disk-persisted (SharedPreferences) and each entry is tagged with the app state at write time — `foreground`, `background`, `backgroundLocked` or `terminated` — so the example's Log screen finally shows what the SDK did while the app was closed, on both platforms with the same entry vocabulary (`Scan`, `Background`, `Região`, `Sync OK`, `Sync falhou`).
 - **Per-minute view in the example's Log screen** — "Detalhado / Por Minuto" toggle mirroring the native iOS `DetectionLogView`: one row per minute with total detections, per-state badges (FG/BG/LK/T) and the number of distinct beacons seen in that minute.
 
 ### Changed
 
-- **Android native SDK pin bumped to v3.7.0** (persisted detection log API), staying in lockstep with iOS `BearoundSDK` 3.6.2.
+- **Android native SDK pin bumped to v3.6.2** (persisted detection log API), staying in lockstep with iOS `BearoundSDK` 3.6.2.
 - The example now reads the native persisted log on Android too (the JS-side optimistic log remains only as a live buffer between refreshes, exactly like on iOS).
 
 ## [3.6.2] - 2026-07-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Real persisted detection log on Android** — `getPersistedLog()` / `clearPersistedLog()` now forward to the native Android SDK v3.7.0 (`getDetectionLogJson()` / `clearDetectionLog()`) instead of resolving a hardcoded `[]`. The log is disk-persisted (SharedPreferences) and each entry is tagged with the app state at write time — `foreground`, `background`, `backgroundLocked` or `terminated` — so the example's Log screen finally shows what the SDK did while the app was closed, on both platforms with the same entry vocabulary (`Scan`, `Background`, `Região`, `Sync OK`, `Sync falhou`).
+- **Per-minute view in the example's Log screen** — "Detalhado / Por Minuto" toggle mirroring the native iOS `DetectionLogView`: one row per minute with total detections, per-state badges (FG/BG/LK/T) and the number of distinct beacons seen in that minute.
+
+### Changed
+
+- **Android native SDK pin bumped to v3.7.0** (persisted detection log API), staying in lockstep with iOS `BearoundSDK` 3.6.2.
+- The example now reads the native persisted log on Android too (the JS-side optimistic log remains only as a live buffer between refreshes, exactly like on iOS).
+
 ## [3.6.2] - 2026-07-25
 
 ### Changed

--- a/EVENT-PARITY.md
+++ b/EVENT-PARITY.md
@@ -28,6 +28,6 @@ Os 8 eventos "comuns" têm nomes por convenção de cada plataforma (iOS `didX`,
 
 | Conceito | iOS | Android | RN | Flutter |
 |---|---|---|---|---|
-| Detection log | `getDetectionLogJson()` / `clearDetectionLog()` | `getDetectionLogJson()` / `clearDetectionLog()` (SDK 3.7.0+, 1:1 com iOS) | `getPersistedLog()` / `clearPersistedLog()` (ambas as plataformas) | idem RN (ambas as plataformas) |
+| Detection log | `getDetectionLogJson()` / `clearDetectionLog()` | `getDetectionLogJson()` / `clearDetectionLog()` (SDK 3.6.2+, 1:1 com iOS) | `getPersistedLog()` / `clearPersistedLog()` (ambas as plataformas) | idem RN (ambas as plataformas) |
 
 - O snapshot `diagnostics()` do Android 3.3.1 deliberadamente **não** é bridged — RN/Flutter expõem getters individuais (`getSdkVersion`, `getBluetoothState`, etc.) em vez do objeto agregado.

--- a/EVENT-PARITY.md
+++ b/EVENT-PARITY.md
@@ -28,6 +28,6 @@ Os 8 eventos "comuns" têm nomes por convenção de cada plataforma (iOS `didX`,
 
 | Conceito | iOS | Android | RN | Flutter |
 |---|---|---|---|---|
-| Detection log | `getDetectionLogJson()` / `clearDetectionLog()` | ausente no SDK | `getPersistedLog()` / `clearPersistedLog()` (Android resolve `[]`) | idem RN (Android resolve `[]`) |
+| Detection log | `getDetectionLogJson()` / `clearDetectionLog()` | `getDetectionLogJson()` / `clearDetectionLog()` (SDK 3.7.0+, 1:1 com iOS) | `getPersistedLog()` / `clearPersistedLog()` (ambas as plataformas) | idem RN (ambas as plataformas) |
 
 - O snapshot `diagnostics()` do Android 3.3.1 deliberadamente **não** é bridged — RN/Flutter expõem getters individuais (`getSdkVersion`, `getBluetoothState`, etc.) em vez do objeto agregado.

--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ getBluetoothState(): Promise<BluetoothState>; // current Bluetooth adapter state
 // Location authorization (iOS-only; no-op on Android — use requestForegroundPermissions there)
 requestLocationAuthorization(level?: 'always' | 'whenInUse'): Promise<void>;
 
-// Persisted detection log (both platforms; Android needs native SDK 3.7.0+)
+// Persisted detection log (both platforms; Android needs native SDK 3.6.2+)
 // Entries are written natively on every event — including while the app is
 // backgrounded or terminated — so JS can show what happened while it wasn't running.
 getPersistedLog(): Promise<PersistedLogEntry[]>;

--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ getBluetoothState(): Promise<BluetoothState>; // current Bluetooth adapter state
 // Location authorization (iOS-only; no-op on Android — use requestForegroundPermissions there)
 requestLocationAuthorization(level?: 'always' | 'whenInUse'): Promise<void>;
 
-// Persisted detection log (iOS-only; Android resolves [] / no-op)
+// Persisted detection log (both platforms; Android needs native SDK 3.7.0+)
 // Entries are written natively on every event — including while the app is
 // backgrounded or terminated — so JS can show what happened while it wasn't running.
 getPersistedLog(): Promise<PersistedLogEntry[]>;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,8 +76,8 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   // Exact pin, kept in lockstep with the iOS podspec dep (same native release).
-  // v3.7.0 adds the persisted detection log with app-state tagging
+  // v3.6.2 adds the persisted detection log with app-state tagging
   // (getDetectionLogJson/clearDetectionLog, 1:1 with iOS), on top of the 3.6.x
   // line (telemetry handoff, ghost-beacon fixes, scan watchdog).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.7.0'
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.6.2'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,8 +76,8 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   // Exact pin, kept in lockstep with the iOS podspec dep (same native release).
-  // v3.5.0 adds the silent-push wake-up (handleRemoteMessage + BearoundMessagingService)
-  // and the never-crash-the-host hardening, on top of the 3.4.x line (FGS crash fixes,
-  // battery-opt/OEM autostart reliability helpers exposed by the RN bridge).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.6.1'
+  // v3.7.0 adds the persisted detection log with app-state tagging
+  // (getDetectionLogJson/clearDetectionLog, 1:1 with iOS), on top of the 3.6.x
+  // line (telemetry handoff, ghost-beacon fixes, scan watchdog).
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.7.0'
 }

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -291,7 +291,7 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     guarded(promise, "BLUETOOTH_STATE_ERROR") { promise.resolve(currentBluetoothState()) }
   }
 
-  // Persisted detection log — Android SDK 3.7.0+ expõe getDetectionLogJson/
+  // Persisted detection log — Android SDK 3.6.2+ expõe getDetectionLogJson/
   // clearDetectionLog (1:1 com o iOS): entradas Scan/Background/Região/Sync
   // taggeadas com o estado do app (foreground/background/backgroundLocked/
   // terminated), persistidas em disco — sobrevivem à morte do processo.

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -291,14 +291,19 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     guarded(promise, "BLUETOOTH_STATE_ERROR") { promise.resolve(currentBluetoothState()) }
   }
 
-  // Detection log é iOS-only (o Android SDK não expõe getDetectionLogJson/
-  // clearDetectionLog) — paridade documentada em EVENT-PARITY.md.
+  // Persisted detection log — Android SDK 3.7.0+ expõe getDetectionLogJson/
+  // clearDetectionLog (1:1 com o iOS): entradas Scan/Background/Região/Sync
+  // taggeadas com o estado do app (foreground/background/backgroundLocked/
+  // terminated), persistidas em disco — sobrevivem à morte do processo.
   override fun getPersistedLog(promise: Promise) {
-    promise.resolve("[]")
+    guarded(promise, "PERSISTED_LOG_ERROR") { promise.resolve(sdk.getDetectionLogJson()) }
   }
 
   override fun clearPersistedLog(promise: Promise) {
-    promise.resolve(null)
+    guarded(promise, "PERSISTED_LOG_ERROR") {
+      sdk.clearDetectionLog()
+      promise.resolve(null)
+    }
   }
 
   private fun currentBluetoothState(): String {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -11,8 +11,12 @@
       tools:targetApi="s" />
 
   <!-- Location — legacy only: required to run a BLE scan on API <= 30. -->
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
+  <!-- No maxSdkVersion: the example follows the native BearoundScan architecture —
+       location + nearby + notifications on every release. Capping at 30 leaves the
+       permission undeclared on Android 12+ (unrequestable, invisible in Settings),
+       the exact bug fixed in the Flutter example (bearound-flutter-sdk#50). -->
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
   <!-- Foreground service: CONNECTED_DEVICE (BLE) on Android 14+.
        The connectedDevice service (BeaconScanService) is provided by the native SDK via manifest merge. -->

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -244,11 +244,10 @@ export default function App() {
     });
   }, []);
 
-  // Load the NATIVE persisted log (iOS-only — the Android SDK exposes no
-  // detection-log API and always resolves [], which would wipe the optimistic
-  // in-memory log; on Android we keep the JS log as the only source).
+  // Load the NATIVE persisted log — source of truth on both platforms
+  // (Android since native SDK 3.7.0). Optimistic JS entries from pushLog are
+  // replaced by the native log on every refresh, exactly like on iOS.
   const refreshLog = useCallback(async () => {
-    if (Platform.OS !== 'ios') return;
     try {
       const entries = await BeAround.getPersistedLog();
       setDetectionLog(entries as unknown as DetectionLogEntry[]);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -245,7 +245,7 @@ export default function App() {
   }, []);
 
   // Load the NATIVE persisted log — source of truth on both platforms
-  // (Android since native SDK 3.7.0). Optimistic JS entries from pushLog are
+  // (Android since native SDK 3.6.2). Optimistic JS entries from pushLog are
   // replaced by the native log on every refresh, exactly like on iOS.
   const refreshLog = useCallback(async () => {
     try {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   AppState,
   Button,
+  PermissionsAndroid,
   Platform,
   Pressable,
   SafeAreaView,
@@ -367,6 +368,23 @@ export default function App() {
   }, [updatePermissionStatus]);
 
   const requestPermissions = useCallback(async () => {
+    // Native BearoundScan architecture: the example asks for the THREE
+    // permission groups — location + nearby devices + notifications. The SDK's
+    // ensurePermissions deliberately skips location on Android 12+ (Play-policy
+    // stance for generic hosts), so the example requests it itself, exactly
+    // like the native and Flutter samples do.
+    if (Platform.OS === 'android') {
+      await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+        {
+          title: 'Permissão de Localização',
+          message:
+            'Localização habilita o segundo olho de detecção (região/beacons).',
+          buttonPositive: 'OK',
+          buttonNegative: 'Cancelar',
+        }
+      );
+    }
     const status = await ensurePermissions({ askBackground: true });
     updatePermissionStatus(status);
 

--- a/example/src/LogModal.tsx
+++ b/example/src/LogModal.tsx
@@ -35,8 +35,76 @@ const FILTERS: Array<{ key: Filter; label: string }> = [
 const fmt = (ms: number) =>
   new Date(ms).toLocaleTimeString('pt-BR', { hour12: false });
 
+// Per-minute aggregation (mirrors the native iOS DetectionLogView and the
+// Flutter example): one row per minute with total, per-state counts and how
+// many distinct beacons ("major.minor" parsed from Scan details) were seen.
+type ViewMode = 'detail' | 'grouped';
+
+type MinuteGroup = {
+  key: number;
+  date: Date;
+  total: number;
+  fg: number;
+  bg: number;
+  lk: number;
+  tm: number;
+  uniqueBeacons: number;
+};
+
+const BEACON_ID_PATTERN = /\b(\d+\.\d+)\b/g;
+
+function groupByMinute(entries: DetectionLogEntry[]): MinuteGroup[] {
+  const buckets = new Map<number, DetectionLogEntry[]>();
+  for (const e of entries) {
+    const t = new Date(e.timestamp);
+    const key = new Date(
+      t.getFullYear(),
+      t.getMonth(),
+      t.getDate(),
+      t.getHours(),
+      t.getMinutes()
+    ).getTime();
+    const list = buckets.get(key);
+    if (list) {
+      list.push(e);
+    } else {
+      buckets.set(key, [e]);
+    }
+  }
+  const groups: MinuteGroup[] = [];
+  for (const [key, list] of buckets) {
+    const ids = new Set<string>();
+    for (const e of list) {
+      if (e.type === 'Scan') {
+        for (const m of e.detail.matchAll(BEACON_ID_PATTERN)) {
+          ids.add(m[1]!);
+        }
+      }
+    }
+    const countOf = (s: AppStateBucket) =>
+      list.filter((e) => e.state === s).length;
+    groups.push({
+      key,
+      date: new Date(key),
+      total: list.length,
+      fg: countOf('foreground'),
+      bg: countOf('background'),
+      lk: countOf('backgroundLocked'),
+      tm: countOf('terminated'),
+      uniqueBeacons: ids.size,
+    });
+  }
+  return groups.sort((a, b) => b.key - a.key);
+}
+
+const fmtMinute = (d: Date) => {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
 export function LogModal(props: LogModalProps) {
   const [filter, setFilter] = useState<Filter>('all');
+  const [viewMode, setViewMode] = useState<ViewMode>('detail');
 
   const counts = {
     foreground: props.entries.filter((e) => e.state === 'foreground').length,
@@ -97,6 +165,36 @@ export function LogModal(props: LogModalProps) {
           />
         </View>
 
+        <View style={styles.viewModeRow}>
+          {(
+            [
+              { key: 'detail', label: 'Detalhado' },
+              { key: 'grouped', label: 'Por Minuto' },
+            ] as Array<{ key: ViewMode; label: string }>
+          ).map((m) => {
+            const active = viewMode === m.key;
+            return (
+              <Pressable
+                key={m.key}
+                style={[
+                  styles.viewModeButton,
+                  active && styles.viewModeButtonActive,
+                ]}
+                onPress={() => setViewMode(m.key)}
+              >
+                <Text
+                  style={[
+                    styles.viewModeText,
+                    active && styles.viewModeTextActive,
+                  ]}
+                >
+                  {m.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
         <View style={styles.filterRow}>
           {FILTERS.map((f) => {
             const active = filter === f.key;
@@ -122,6 +220,33 @@ export function LogModal(props: LogModalProps) {
         <ScrollView contentContainerStyle={styles.content}>
           {filtered.length === 0 ? (
             <Text style={styles.empty}>Nenhum evento registrado ainda.</Text>
+          ) : viewMode === 'grouped' ? (
+            groupByMinute(filtered).map((g) => (
+              <View key={g.key} style={styles.minuteRow}>
+                <View style={styles.minuteTop}>
+                  <Text style={styles.minuteDate}>{fmtMinute(g.date)}</Text>
+                  <Text style={styles.minuteTotal}>{g.total} detecções</Text>
+                </View>
+                <View style={styles.minuteBadges}>
+                  {g.fg > 0 && (
+                    <CountBadge label="FG" count={g.fg} color="#4caf50" />
+                  )}
+                  {g.bg > 0 && (
+                    <CountBadge label="BG" count={g.bg} color="#ff9800" />
+                  )}
+                  {g.lk > 0 && (
+                    <CountBadge label="LK" count={g.lk} color="#607d8b" />
+                  )}
+                  {g.tm > 0 && (
+                    <CountBadge label="T" count={g.tm} color="#9c27b0" />
+                  )}
+                  <View style={styles.minuteSpacer} />
+                  <Text style={styles.minuteBeacons}>
+                    {g.uniqueBeacons} beacon{g.uniqueBeacons === 1 ? '' : 's'}
+                  </Text>
+                </View>
+              </View>
+            ))
           ) : (
             filtered.map((entry) => (
               <View key={entry.id} style={styles.row}>
@@ -152,6 +277,24 @@ export function LogModal(props: LogModalProps) {
         </ScrollView>
       </View>
     </Modal>
+  );
+}
+
+function CountBadge({
+  label,
+  count,
+  color,
+}: {
+  label: string;
+  count: number;
+  color: string;
+}) {
+  return (
+    <View style={[styles.countBadge, { backgroundColor: `${color}26` }]}>
+      <Text style={[styles.countBadgeText, { color }]}>
+        {label} {count}
+      </Text>
+    </View>
   );
 }
 
@@ -203,6 +346,24 @@ const styles = StyleSheet.create({
   },
   summaryValue: { fontSize: 20, fontWeight: '700' },
   summaryLabel: { color: '#9e9e9e', fontSize: 10, marginTop: 2 },
+  viewModeRow: {
+    flexDirection: 'row',
+    marginHorizontal: 16,
+    marginTop: 12,
+    borderRadius: 8,
+    backgroundColor: '#141414',
+    padding: 3,
+    gap: 3,
+  },
+  viewModeButton: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  viewModeButtonActive: { backgroundColor: '#1976d2' },
+  viewModeText: { color: '#bdbdbd', fontSize: 12, fontWeight: '600' },
+  viewModeTextActive: { color: '#fff' },
   filterRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
@@ -250,4 +411,37 @@ const styles = StyleSheet.create({
   },
   rowDetail: { color: '#bdbdbd', fontSize: 11, marginTop: 2 },
   rowState: { fontSize: 9, fontWeight: '700', marginTop: 2 },
+  minuteRow: {
+    backgroundColor: '#141414',
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    marginBottom: 6,
+  },
+  minuteTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  minuteDate: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '700',
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  minuteTotal: { color: '#bdbdbd', fontSize: 11 },
+  minuteBadges: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 6,
+    gap: 6,
+  },
+  minuteSpacer: { flex: 1 },
+  minuteBeacons: { color: '#9e9e9e', fontSize: 10 },
+  countBadge: {
+    borderRadius: 4,
+    paddingVertical: 2,
+    paddingHorizontal: 6,
+  },
+  countBadgeText: { fontSize: 9, fontWeight: '700' },
 });

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -47,8 +47,8 @@ export interface Spec extends TurboModule {
   requestLocationAuthorization(level: string): Promise<void>;
 
   // Persistent detection log written natively (survives termination / captures
-  // closed-state events). Returns a JSON string array of entries
-  // (iOS-only; Android resolves '[]').
+  // closed-state events). Returns a JSON string array of entries.
+  // Both platforms (Android since native SDK 3.7.0).
   getPersistedLog(): Promise<string>;
   clearPersistedLog(): Promise<void>;
 

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -48,7 +48,7 @@ export interface Spec extends TurboModule {
 
   // Persistent detection log written natively (survives termination / captures
   // closed-state events). Returns a JSON string array of entries.
-  // Both platforms (Android since native SDK 3.7.0).
+  // Both platforms (Android since native SDK 3.6.2).
   getPersistedLog(): Promise<string>;
   clearPersistedLog(): Promise<void>;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -534,16 +534,16 @@ export async function getBluetoothState(): Promise<BluetoothState> {
 }
 
 /**
- * App-state bucket recorded natively for each persisted log entry. The
- * persisted log is iOS-only (see {@link getPersistedLog}), so these states
- * only ever come from iOS.
+ * App-state bucket recorded natively for each persisted log entry
+ * (see {@link getPersistedLog}). Both platforms report the same states.
  *
  * - `foreground` — app active and on screen.
  * - `background` — app backgrounded, device screen unlocked.
  * - `backgroundLocked` — app backgrounded AND device screen locked
- *   (iOS: `isProtectedDataAvailable`).
- * - `terminated` — event fired during a system-initiated relaunch
- *   (BLE/region wake-up) BEFORE the app's UI became active.
+ *   (iOS: `isProtectedDataAvailable`; Android: keyguard/screen off).
+ * - `terminated` — event fired while the process was system-started and the
+ *   UI never became active (iOS: BLE/region relaunch; Android:
+ *   broadcast-delivered scan, boot receiver or watchdog alarm).
  */
 export type PersistedLogState =
   | 'foreground'
@@ -560,11 +560,10 @@ export type PersistedLogEntry = {
 };
 
 /**
- * Read the **native** detection log. **iOS-only** — the Android SDK 3.3.1
- * exposes no detection-log API; Android always resolves `[]` (see
- * EVENT-PARITY.md). On iOS, entries are persisted natively on every event,
- * including backgrounded/terminated-state wakes, so JS can show what happened
- * while it wasn't running.
+ * Read the **native** detection log — both platforms (Android since native
+ * SDK 3.7.0). Entries are persisted natively on every event, including
+ * backgrounded/terminated-state wakes, so JS can show what happened while it
+ * wasn't running.
  */
 export async function getPersistedLog(): Promise<PersistedLogEntry[]> {
   const raw = await Native.getPersistedLog();
@@ -588,7 +587,7 @@ export async function getPersistedLog(): Promise<PersistedLogEntry[]> {
   }
 }
 
-/** Clear the native persisted detection log. **iOS-only** (no-op on Android). */
+/** Clear the native persisted detection log (both platforms). */
 export async function clearPersistedLog(): Promise<void> {
   await Native.clearPersistedLog();
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -561,7 +561,7 @@ export type PersistedLogEntry = {
 
 /**
  * Read the **native** detection log — both platforms (Android since native
- * SDK 3.7.0). Entries are persisted natively on every event, including
+ * SDK 3.6.2). Entries are persisted natively on every event, including
  * backgrounded/terminated-state wakes, so JS can show what happened while it
  * wasn't running.
  */


### PR DESCRIPTION
## What

The persisted detection log — the diagnostic screen that answers "what did the SDK see, and with the app in which state?" — now works on **Android** too, and the example's Log screen gains the **per-minute aggregation view**, closing the parity loop with the native iOS `DetectionLogView` and with `bearound-flutter-sdk#53`.

Before this PR, `getPersistedLog()` resolved a hardcoded `[]` on Android (an explicit iOS-only stub), so the Log screen relied on a JS-side in-memory buffer that dies with the process — `terminated` could never be shown on Android.

## How

- **Bridge (Android)**: `getPersistedLog` / `clearPersistedLog` forward to the native SDK's `getDetectionLogJson()` / `clearDetectionLog()` (new in `bearound-android-sdk` **v3.7.0**), wrapped in the module's never-crash guard.
- **Pin**: `com.github.Bearound:bearound-android-sdk` bumped `v3.6.1 → v3.7.0` (the release that ships the log API — [changelog](https://github.com/Bearound/bearound-android-sdk/blob/main/CHANGELOG.md)).
- **Example**: the `Platform.OS !== 'ios'` guard in `refreshLog` is gone — Android reads the same native log; optimistic JS entries remain only as a live buffer between refreshes, exactly like on iOS. `LogModal` gains the **Detalhado / Por Minuto** toggle: one row per minute with total detections, per-state badges (FG/BG/LK/T, shown only when non-zero) and the number of distinct beacons in that minute.
- **Docs**: EVENT-PARITY.md, README and the TS docs no longer mark the log as iOS-only.

## Log contract (identical on iOS, Android, RN, Flutter)

| `type` | `detail` |
|---|---|
| `Scan` | `0.205 rssi=-61` (comma-joined, throttled: 1 entry per composition change or 10 s) |
| `Background` | `N beacon(s) detectado(s)` |
| `Região` | `Entrou na zona do beacon` / `Saiu da zona do beacon` |
| `Sync OK` | `N beacon(s) enviados ao ingester` |
| `Sync falhou` | `N beacon(s) · <erro>` |

States: `foreground` / `background` / `backgroundLocked` / `terminated` (`terminated` = process started by the system with the app closed — the entry that proves the SDK worked while nobody was watching). Reference: [`bearound-android-sdk/docs/DETECTION-LOG.md`](https://github.com/Bearound/bearound-android-sdk/blob/main/docs/DETECTION-LOG.md).

## Validation

- `tsc` clean, `eslint` 0 errors (warnings are pre-existing inline-style ones), `jest` 148/148 passing.
- The same mechanism was field-validated on the Flutter wrapper and the native Android sample (Galaxy A16, Android 16): background entries with screen off, and 5 genuine `terminated` entries after a reboot with the app never opened (SDK revived headless via `BOOT_COMPLETED`).
- On-device validation of this RN example (BG + terminated evidence run) is the natural next step once a bench device is plugged in.
