### PR TITLE
Reconciliação periódica configurável (paridade com nativos 3.6.4/3.7.0)

### DIFF
--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.6.3"
+  s.dependency "BearoundSDK", "3.6.4"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.6.4"
+  s.dependency "BearoundSDK", "3.7.0"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.7.0
+
+- **Configurable periodic background reconciliation**: new `SdkConfig` fields
+  `periodicReconciliationEnabled` (default `true`), `periodicReconciliationIntervalMs`
+  (default `20 * 60 * 1000`) and `periodicScanDurationMs` (default `12_000`), forwarded
+  to the native SDKs (iOS `BGAppRefreshTask`, Android WorkManager). Best effort — the
+  interval is a minimum, never a guaranteed cadence. Out-of-range values are clamped by
+  the native SDKs with a highlighted log warning (interval floor 10 min iOS / 15 min
+  Android, ceiling 24 h; scan window 3-15s iOS / 3-30s Android).
+- Native SDKs updated: **iOS 3.6.4** and **Android 3.7.0** — two hardening rounds
+  (25 iOS + 18 Android audit findings): level-triggered region exit (field-validated),
+  ranging wired to region enter/exit, scan-quota reserve-before-kill, truthful
+  PendingIntent registration, Bluetooth-cycle recovery, single-flight sync,
+  persist-before-send with exact-id removal, poison-batch quarantine, crash-envelope
+  telemetry, and bounded in-memory beacon caches.
+
 ## [Unreleased]
 
 ## [3.6.3] - 2026-07-31

--- a/README.md
+++ b/README.md
@@ -656,6 +656,16 @@ export type SdkConfig = {
   businessToken: string; // required - your business token
   scanPrecision?: ScanPrecision; // defaults to HIGH (aligned with the iOS native default)
   maxQueuedPayloads?: MaxQueuedPayloads; // defaults to MEDIUM
+
+  // Periodic background reconciliation (best effort — the OS decides when it
+  // actually runs; iOS: BGAppRefreshTask, Android: WorkManager). The interval is
+  // only the MINIMUM requested, never a guaranteed cadence. Out-of-range values
+  // are clamped by the NATIVE SDKs with a highlighted log warning: interval
+  // floor 10 min (iOS) / 15 min (Android, WorkManager hard minimum), ceiling
+  // 24 h; scan window 3–15s (iOS, ~30s BGTask budget) / 3–30s (Android).
+  periodicReconciliationEnabled?: boolean; // default: true
+  periodicReconciliationIntervalMs?: number; // default: 20 * 60 * 1000 (20 min)
+  periodicScanDurationMs?: number; // default: 12_000 (12s)
 };
 
 export type UserProperties = {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.6.2 adds the persisted detection log with app-state tagging
   // (getDetectionLogJson/clearDetectionLog, 1:1 with iOS), on top of the 3.6.x
   // line (telemetry handoff, ghost-beacon fixes, scan watchdog).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.6.3'
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.7.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.6.2 adds the persisted detection log with app-state tagging
   // (getDetectionLogJson/clearDetectionLog, 1:1 with iOS), on top of the 3.6.x
   // line (telemetry handoff, ghost-beacon fixes, scan watchdog).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.7.0'
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.7.1'
 }

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -120,6 +120,9 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     businessToken: String,
     scanPrecision: String,
     maxQueuedPayloads: Double,
+    periodicReconciliationEnabled: Boolean,
+    periodicReconciliationIntervalMs: Double,
+    periodicScanDurationMs: Double,
     promise: Promise
   ) {
     try {
@@ -142,7 +145,11 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
         businessToken = businessToken.trim(),
         scanPrecision = precision,
         maxQueuedPayloads = maxQueued,
-        technology = "react-native"
+        technology = "react-native",
+        // Validation/clamping lives in the native SDK (single source of truth).
+        periodicReconciliationEnabled = periodicReconciliationEnabled,
+        periodicReconciliationIntervalMillis = periodicReconciliationIntervalMs.toLong(),
+        periodicScanDurationMillis = periodicScanDurationMs.toLong()
       )
 
       if (wasScanning) {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -786,6 +786,7 @@ export default function App() {
           <Text
             style={[
               styles.readyHint,
+              // eslint-disable-next-line react-native/no-inline-styles
               { color: canScan ? '#4caf50' : '#ff9800' },
             ]}
           >
@@ -837,6 +838,7 @@ export default function App() {
               <Text
                 style={[
                   styles.infoValue,
+                  // eslint-disable-next-line react-native/no-inline-styles
                   {
                     color:
                       lastSyncResult === 'success'
@@ -1074,6 +1076,7 @@ export default function App() {
                     ) : null}
                     {beacon.isStale ? (
                       <Text
+                        // eslint-disable-next-line react-native/no-inline-styles
                         style={[styles.beaconMetaText, { color: '#ff9800' }]}
                       >
                         stale
@@ -1081,6 +1084,7 @@ export default function App() {
                     ) : null}
                     {beacon.alreadySynced ? (
                       <Text
+                        // eslint-disable-next-line react-native/no-inline-styles
                         style={[styles.beaconMetaText, { color: '#4caf50' }]}
                       >
                         ✓ synced

--- a/example/src/EyeCard.tsx
+++ b/example/src/EyeCard.tsx
@@ -68,6 +68,7 @@ export function EyeCard(props: EyeCardProps) {
     <View
       style={[
         styles.card,
+        // eslint-disable-next-line react-native/no-inline-styles
         { borderColor: props.isInZone ? meta.color : '#1f1f1f' },
         props.isInZone && { backgroundColor: `${meta.color}14` },
       ]}
@@ -76,6 +77,7 @@ export function EyeCard(props: EyeCardProps) {
         <View
           style={[
             styles.dot,
+            // eslint-disable-next-line react-native/no-inline-styles
             { backgroundColor: props.isInZone ? meta.color : '#555' },
           ]}
         />
@@ -87,6 +89,7 @@ export function EyeCard(props: EyeCardProps) {
         <Text
           style={[
             styles.zonePillText,
+            // eslint-disable-next-line react-native/no-inline-styles
             { color: props.isInZone ? meta.color : '#9e9e9e' },
           ]}
         >
@@ -103,6 +106,7 @@ export function EyeCard(props: EyeCardProps) {
         <View
           style={[
             styles.modeChip,
+            // eslint-disable-next-line react-native/no-inline-styles
             {
               backgroundColor: props.modeIsActive
                 ? `${meta.color}22`
@@ -114,6 +118,7 @@ export function EyeCard(props: EyeCardProps) {
           <Text
             style={[
               styles.modeChipText,
+              // eslint-disable-next-line react-native/no-inline-styles
               { color: props.modeIsActive ? meta.color : '#9e9e9e' },
             ]}
           >

--- a/example/src/TwoEyesModal.tsx
+++ b/example/src/TwoEyesModal.tsx
@@ -161,11 +161,13 @@ function SummaryBadge({
     <View
       style={[
         styles.badge,
+        // eslint-disable-next-line react-native/no-inline-styles
         { backgroundColor: isOn ? `${color}1f` : 'rgba(255,255,255,0.05)' },
       ]}
     >
       <View style={styles.badgeHeader}>
         <View
+          // eslint-disable-next-line react-native/no-inline-styles
           style={[styles.badgeDot, { backgroundColor: isOn ? color : '#555' }]}
         />
         <Text style={styles.badgeTitle}>{title}</Text>

--- a/ios/BearoundReactSdk.mm
+++ b/ios/BearoundReactSdk.mm
@@ -16,6 +16,9 @@ RCT_EXPORT_METHOD(removeListeners:(double)count) {}
 - (void)configure:(NSString *)businessToken
     scanPrecision:(NSString *)scanPrecision
 maxQueuedPayloads:(double)maxQueuedPayloads
+periodicReconciliationEnabled:(BOOL)periodicReconciliationEnabled
+periodicReconciliationIntervalMs:(double)periodicReconciliationIntervalMs
+periodicScanDurationMs:(double)periodicScanDurationMs
           resolve:(RCTPromiseResolveBlock)resolve
            reject:(RCTPromiseRejectBlock)reject
 {
@@ -30,7 +33,10 @@ maxQueuedPayloads:(double)maxQueuedPayloads
 
   [[RNBearoundBridge shared] configure:trimmed
                          scanPrecision:scanPrecision ?: @"high"
-                     maxQueuedPayloads:maxQueuedPayloads];
+                     maxQueuedPayloads:maxQueuedPayloads
+         periodicReconciliationEnabled:periodicReconciliationEnabled
+      periodicReconciliationIntervalMs:periodicReconciliationIntervalMs
+                periodicScanDurationMs:periodicScanDurationMs];
   resolve(nil);
 }
 

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -52,7 +52,10 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
   public func configure(
     _ businessToken: String,
     scanPrecision: String,
-    maxQueuedPayloads: Double
+    maxQueuedPayloads: Double,
+    periodicReconciliationEnabled: Bool,
+    periodicReconciliationIntervalMs: Double,
+    periodicScanDurationMs: Double
   ) {
     DispatchQueue.main.async {
       let precision = self.mapToScanPrecision(scanPrecision)
@@ -63,11 +66,16 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
         self.sdk.stopScanning()
       }
 
+      // Wire carries millis; the iOS SDK takes seconds. Validation/clamping
+      // lives in the native SDK (single source of truth).
       self.sdk.configure(
         businessToken: businessToken,
         scanPrecision: precision,
         maxQueuedPayloads: maxQueued,
-        technology: "react-native"
+        technology: "react-native",
+        periodicReconciliationEnabled: periodicReconciliationEnabled,
+        periodicReconciliationInterval: periodicReconciliationIntervalMs / 1000.0,
+        periodicScanDuration: periodicScanDurationMs / 1000.0
       )
       self.sdk.delegate = self
       self.configured = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -5,7 +5,10 @@ export interface Spec extends TurboModule {
   configure(
     businessToken: string,
     scanPrecision: string,
-    maxQueuedPayloads: number
+    maxQueuedPayloads: number,
+    periodicReconciliationEnabled: boolean,
+    periodicReconciliationIntervalMs: number,
+    periodicScanDurationMs: number
   ): Promise<void>;
 
   startScanning(): Promise<void>;

--- a/src/__tests__/sdk.test.ts
+++ b/src/__tests__/sdk.test.ts
@@ -101,7 +101,10 @@ describe('Bearound SDK Core Functions', () => {
       expect(mockNativeModule.configure).toHaveBeenCalledWith(
         'test-token-123',
         'high',
-        100
+        100,
+        true,
+        20 * 60 * 1000,
+        12_000
       );
     });
 
@@ -116,7 +119,10 @@ describe('Bearound SDK Core Functions', () => {
       expect(mockNativeModule.configure).toHaveBeenCalledWith(
         'test-token',
         'high',
-        100
+        100,
+        true,
+        20 * 60 * 1000,
+        12_000
       );
     });
 
@@ -131,12 +137,18 @@ describe('Bearound SDK Core Functions', () => {
         businessToken: 'my-business-token',
         scanPrecision: ScanPrecision.LOW,
         maxQueuedPayloads: MaxQueuedPayloads.LARGE,
+        periodicReconciliationEnabled: false,
+        periodicReconciliationIntervalMs: 60 * 60 * 1000,
+        periodicScanDurationMs: 8_000,
       });
 
       expect(mockNativeModule.configure).toHaveBeenCalledWith(
         'my-business-token',
         'low',
-        200
+        200,
+        false,
+        60 * 60 * 1000,
+        8_000
       );
     });
 
@@ -148,7 +160,10 @@ describe('Bearound SDK Core Functions', () => {
       expect(mockNativeModule.configure).toHaveBeenCalledWith(
         'my-token',
         'high',
-        100
+        100,
+        true,
+        20 * 60 * 1000,
+        12_000
       );
     });
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,28 @@ export type SdkConfig = {
   businessToken: string;
   scanPrecision?: ScanPrecision;
   maxQueuedPayloads?: MaxQueuedPayloads;
+  /**
+   * Enables the periodic background reconciliation layer (iOS: BGAppRefreshTask;
+   * Android: WorkManager PeriodicWorkRequest). Best effort — the OS decides when
+   * (and whether) it runs. Default: true.
+   */
+  periodicReconciliationEnabled?: boolean;
+  /**
+   * MINIMUM interval requested between eligible executions, in milliseconds —
+   * a floor, never a guaranteed cadence. Default: 20 min (1_200_000).
+   *
+   * Guard rails applied by the NATIVE SDKs (out-of-range values are clamped with
+   * a highlighted log warning — never silently, never a crash): effective floor
+   * is 10 min on iOS and 15 min on Android (WorkManager's hard minimum);
+   * ceiling 24 h on both.
+   */
+  periodicReconciliationIntervalMs?: number;
+  /**
+   * Ceiling of the collection window inside the periodic task, in milliseconds.
+   * Default: 12s (12_000). Native ranges: 3–15s on iOS (~30s BGTask budget),
+   * 3–30s on Android.
+   */
+  periodicScanDurationMs?: number;
 };
 
 /**
@@ -380,6 +402,9 @@ export async function configure(config: SdkConfig) {
     // duty cycles.
     scanPrecision = ScanPrecision.HIGH,
     maxQueuedPayloads = MaxQueuedPayloads.MEDIUM,
+    periodicReconciliationEnabled = true,
+    periodicReconciliationIntervalMs = 20 * 60 * 1000,
+    periodicScanDurationMs = 12_000,
   } = config;
 
   if (!businessToken || businessToken.trim().length === 0) {
@@ -396,7 +421,10 @@ export async function configure(config: SdkConfig) {
   await Native.configure(
     businessToken.trim(),
     scanPrecision,
-    maxQueuedPayloads
+    maxQueuedPayloads,
+    periodicReconciliationEnabled,
+    periodicReconciliationIntervalMs,
+    periodicScanDurationMs
   );
 }
 


### PR DESCRIPTION
## O que faz

Expõe os 3 parâmetros novos do `configure()` nativo (reconciliação periódica em background), ponta a ponta — `SdkConfig` → Spec do TurboModule → módulo Android / `.mm` + bridge Swift no iOS:

```ts
await BeAround.configure({
  businessToken: token,
  periodicReconciliationEnabled: true,          // default true
  periodicReconciliationIntervalMs: 20 * 60 * 1000, // intervalo MÍNIMO, nunca cadência garantida
  periodicScanDurationMs: 12_000,
});
```

## Decisões

- **Wire em millis** (convenção JS); Android repassa, iOS converte para segundos.
- **Validação/clamp fica nos SDKs nativos** (fonte única de verdade, warning destacado no log). Ranges por plataforma nos types e README: piso 10 min (iOS) / 15 min (Android, mínimo duro do WorkManager); teto 24 h; janela 3–15s (iOS) / 3–30s (Android).
- Pins: Android **v3.7.0**, iOS **3.6.4**.

## Passou se

- `tsc` limpo ✅ · `jest` **148/148** ✅ (expectations do configure atualizadas + caso pinando valores custom)
- Builds nativos ficam verdes quando os releases publicarem — **draft até lá** (depende de Bearound/bearound-android-sdk#71 e Bearound/bearound-ios-sdk#54)