### PR TITLE
feat: pin native 3.8.0 and expose presence heartbeat + Wi-Fi collection

### DIFF
--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.7.0"
+  s.dependency "BearoundSDK", "3.8.0"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.8.0
+
+### Added
+- **Um scan que não acha nada também reporta.** Até agora um aparelho que não via beacon nem
+  par ficava calado, e o backend não distinguia "não há cobertura aqui" de "o app não estava
+  rodando". Esses scans passam a subir a localização do próprio aparelho e o Wi-Fi ao redor.
+  Novo `configure({ presenceHeartbeatIntervalMs })` — **5 min** por padrão, faixa aceita de
+  1 min a 1 h, `0` desliga. Só o upload é limitado; o scan não muda.
+- **Camada de encontros (mesh).** O SDK nativo passa a registrar outros aparelhos com o SDK por
+  perto, não só beacons, e sobe esses encontros mesmo sem beacon no alcance. Nenhuma API JS
+  envolvida.
+- **Observações de Wi-Fi.** Os APs visíveis vão no payload, cada um com um `apId` derivado por
+  hash — o BSSID cru nunca sai do aparelho. `NEARBY_WIFI_DEVICES` agora é declarada no
+  manifesto da biblioteca: ela é pedida em runtime desde a versão anterior, mas sem a
+  declaração o pedido era negado na hora, sem diálogo.
+- **`configure({ requestTrackingOnStart })`** (iOS): passe `false` para escolher o momento do
+  prompt de App Tracking Transparency e chamar `requestTrackingAuthorization()` você mesmo.
+  Ignorado no Android.
+
+### Changed
+- SDKs nativos: iOS **3.8.0**, Android **v3.8.0**.
+- O app de exemplo ganhou `NSUserTrackingUsageDescription` e a capability *Access WiFi
+  Information* — sem elas o prompt de ATT não aparece e a coleta de Wi-Fi fica muda.
+
 ## 3.7.0
 
 - **Configurable periodic background reconciliation**: new `SdkConfig` fields

--- a/README.md
+++ b/README.md
@@ -165,6 +165,63 @@ _These four `NS…UsageDescription` strings appear in **your** users' iOS permis
 
 ---
 
+## Wi-Fi observations
+
+Alongside each beacon sighting the SDK reports the **access points visible at that moment**.
+An access point seen repeatedly next to a known beacon gets a position of its own, and from
+then on it can place a device even where no beacon reaches.
+
+**No network name is used as identity.** What travels is `apId` — a one-way hash of the
+access point's hardware address, canonicalised so the same router yields the same identifier
+on both platforms.
+
+| Platform | What it reports | What you must do |
+|---|---|---|
+| **Android** | The connected access point **and its neighbours**, with RSSI | Nothing — `requestPermissions()` already asks for `NEARBY_WIFI_DEVICES` on 13+, in the same "Nearby devices" group as Bluetooth (usually no second dialog) |
+| **iOS** | Only the **connected** access point, without RSSI (there is no public API for neighbours) | Add the **Access WiFi Information** capability in Xcode (Signing & Capabilities → + Capability) |
+
+Nothing degrades if you skip the iOS capability: the field is simply omitted and every other
+feature behaves the same.
+
+## Advertising identifier (IDFA / AAID)
+
+The SDK can report the advertising identifier — what makes audiences built from beacon visits
+usable in ad platforms.
+
+**iOS — you must ask.** Add to your `Info.plist`:
+
+```xml
+<key>NSUserTrackingUsageDescription</key>
+<string>We use this identifier to measure visits and show you more relevant offers.</string>
+```
+
+and call it in the **foreground**, at a point in your onboarding where the user has just been
+told why:
+
+```ts
+import { requestTrackingAuthorization } from '@bearound/react-native-sdk';
+
+const status = await requestTrackingAuthorization();
+// 'authorized' | 'denied' | 'restricted' | 'notDetermined' | 'unavailable'
+```
+
+Without the key iOS shows **no dialog at all** and the status stays `notDetermined` forever.
+Answering is a one-time event per install, so it is safe to call on every launch. To read the
+state without prompting, use `getTrackingAuthorizationStatus()`.
+
+**Android — nothing to ask.** There is no prompt: the user's choice lives in system settings
+and the platform enforces it (opting out zeroes the id and the SDK reports none). To receive
+an id at all, your app needs Play Services on the classpath:
+
+```gradle
+implementation 'com.google.android.gms:play-services-ads-identifier:18.2.0'
+```
+
+> **Store obligations follow the feature, not the SDK:** prompting for tracking obliges you to
+> declare **Tracking** in your App Store privacy label; the `AD_ID` permission obliges you to
+> tick **"Device or other IDs"** in the Play Data Safety form. Apps for children must strip
+> `AD_ID` (Play Families policy).
+
 ## Scan modes (Android)
 
 > On **iOS** scanning is always system-managed (region monitoring + `BGTaskScheduler`). These modes are **Android-only**.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.6.2 adds the persisted detection log with app-state tagging
   // (getDetectionLogJson/clearDetectionLog, 1:1 with iOS), on top of the 3.6.x
   // line (telemetry handoff, ghost-beacon fixes, scan watchdog).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.7.1'
+  implementation 'com.github.Bearound:bearound-android-sdk:v3.8.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.6.2 adds the persisted detection log with app-state tagging
   // (getDetectionLogJson/clearDetectionLog, 1:1 with iOS), on top of the 3.6.x
   // line (telemetry handoff, ghost-beacon fixes, scan watchdog).
-  implementation 'com.github.Bearound:bearound-android-sdk:v3.8.0'
+  implementation 'com.github.Bearound:bearound-android-sdk:3.8.0'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,14 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Wi-Fi observations. ACCESS_WIFI_STATE is install-time; NEARBY_WIFI_DEVICES is the
+         Android 13+ runtime gate that unlocks the NEIGHBOURING access points (without it the
+         system only ever reports the connected one). Declared here, in the library, rather
+         than relying on the native AAR's manifest merge: `src/permissions.ts` asks for it at
+         runtime, and an undeclared permission is denied instantly — no dialog, no error. -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="tiramisu" />
 </manifest>

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -333,6 +333,17 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     promise.resolve(null)
   }
 
+  // App Tracking Transparency is an iOS concept. On Android the advertising-id choice
+  // lives in system settings and the platform enforces it (opting out zeroes the id),
+  // so there is no prompt to show — answer "unavailable" to keep the JS API uniform.
+  override fun requestTrackingAuthorization(promise: Promise) {
+    promise.resolve("unavailable")
+  }
+
+  override fun getTrackingAuthorizationStatus(promise: Promise) {
+    promise.resolve("unavailable")
+  }
+
   // Foreground-service scanning (Android-only) — persistent notification keeps the
   // process alive on aggressive OEMs while scanning in background.
 

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -123,6 +123,10 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     periodicReconciliationEnabled: Boolean,
     periodicReconciliationIntervalMs: Double,
     periodicScanDurationMs: Double,
+    presenceHeartbeatIntervalMs: Double,
+    // Part of the cross-platform signature (the codegen spec is shared), but App
+    // Tracking Transparency is iOS-only — read and dropped here on purpose.
+    requestTrackingOnStart: Boolean,
     promise: Promise
   ) {
     try {
@@ -149,7 +153,8 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
         // Validation/clamping lives in the native SDK (single source of truth).
         periodicReconciliationEnabled = periodicReconciliationEnabled,
         periodicReconciliationIntervalMillis = periodicReconciliationIntervalMs.toLong(),
-        periodicScanDurationMillis = periodicScanDurationMs.toLong()
+        periodicScanDurationMillis = periodicScanDurationMs.toLong(),
+        presenceHeartbeatIntervalMillis = presenceHeartbeatIntervalMs.toLong()
       )
 
       if (wasScanning) {

--- a/example/ios/BearoundReactSdkExample/BearoundReactSdkExample.entitlements
+++ b/example/ios/BearoundReactSdkExample/BearoundReactSdkExample.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<!-- Access WiFi Information: sem esta capability o iOS devolve nil no
+	     NEHotspotNetwork/CNCopyCurrentNetworkInfo e a coleta de Wi-Fi do SDK fica muda. -->
+	<key>com.apple.developer.networking.wifi-info</key>
+	<true/>
 </dict>
 </plist>

--- a/example/ios/BearoundReactSdkExample/Info.plist
+++ b/example/ios/BearoundReactSdkExample/Info.plist
@@ -53,6 +53,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+  <key>NSUserTrackingUsageDescription</key>
+  <string>Usamos o identificador de publicidade para medir e melhorar as campanhas que você vê.</string>
   <key>NSBluetoothAlwaysUsageDescription</key>
   <string>Usamos Bluetooth para detectar lugares próximos e oferecer recursos relevantes.</string>
   <key>NSBluetoothPeripheralUsageDescription</key>

--- a/ios/BearoundReactSdk.mm
+++ b/ios/BearoundReactSdk.mm
@@ -19,6 +19,8 @@ maxQueuedPayloads:(double)maxQueuedPayloads
 periodicReconciliationEnabled:(BOOL)periodicReconciliationEnabled
 periodicReconciliationIntervalMs:(double)periodicReconciliationIntervalMs
 periodicScanDurationMs:(double)periodicScanDurationMs
+presenceHeartbeatIntervalMs:(double)presenceHeartbeatIntervalMs
+requestTrackingOnStart:(BOOL)requestTrackingOnStart
           resolve:(RCTPromiseResolveBlock)resolve
            reject:(RCTPromiseRejectBlock)reject
 {
@@ -36,7 +38,9 @@ periodicScanDurationMs:(double)periodicScanDurationMs
                      maxQueuedPayloads:maxQueuedPayloads
          periodicReconciliationEnabled:periodicReconciliationEnabled
       periodicReconciliationIntervalMs:periodicReconciliationIntervalMs
-                periodicScanDurationMs:periodicScanDurationMs];
+                periodicScanDurationMs:periodicScanDurationMs
+           presenceHeartbeatIntervalMs:presenceHeartbeatIntervalMs
+                requestTrackingOnStart:requestTrackingOnStart];
   resolve(nil);
 }
 

--- a/ios/BearoundReactSdk.mm
+++ b/ios/BearoundReactSdk.mm
@@ -169,6 +169,20 @@ periodicScanDurationMs:(double)periodicScanDurationMs
   resolve(nil);
 }
 
+- (void)requestTrackingAuthorization:(RCTPromiseResolveBlock)resolve
+                              reject:(RCTPromiseRejectBlock)reject
+{
+  [[RNBearoundBridge shared] requestTrackingAuthorization:^(NSString *status) {
+    resolve(status);
+  }];
+}
+
+- (void)getTrackingAuthorizationStatus:(RCTPromiseResolveBlock)resolve
+                                reject:(RCTPromiseRejectBlock)reject
+{
+  resolve([[RNBearoundBridge shared] trackingAuthorizationStatus]);
+}
+
 - (void)enableForegroundScanning:(NSDictionary *)config
                          resolve:(RCTPromiseResolveBlock)resolve
                           reject:(RCTPromiseRejectBlock)reject

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -131,6 +131,23 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
     }
   }
 
+  /// Shows the App Tracking Transparency prompt; once authorised the SDK reports the IDFA.
+  ///
+  /// Main queue and app-active are both required — iOS silently ignores the prompt
+  /// otherwise, leaving the status at `notDetermined` with no error to observe.
+  public func requestTrackingAuthorization(_ completion: @escaping (String) -> Void) {
+    DispatchQueue.main.async {
+      self.sdk.requestTrackingAuthorization { status in
+        completion(status)
+      }
+    }
+  }
+
+  /// ATT status without prompting.
+  public func trackingAuthorizationStatus() -> String {
+    BeAroundSDK.trackingAuthorizationStatus()
+  }
+
   // Bluetooth eye — current CBCentralManager state. Independent of Location.
 
   public func getBluetoothState() -> String {

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -55,7 +55,9 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
     maxQueuedPayloads: Double,
     periodicReconciliationEnabled: Bool,
     periodicReconciliationIntervalMs: Double,
-    periodicScanDurationMs: Double
+    periodicScanDurationMs: Double,
+    presenceHeartbeatIntervalMs: Double,
+    requestTrackingOnStart: Bool
   ) {
     DispatchQueue.main.async {
       let precision = self.mapToScanPrecision(scanPrecision)
@@ -75,7 +77,9 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
         technology: "react-native",
         periodicReconciliationEnabled: periodicReconciliationEnabled,
         periodicReconciliationInterval: periodicReconciliationIntervalMs / 1000.0,
-        periodicScanDuration: periodicScanDurationMs / 1000.0
+        periodicScanDuration: periodicScanDurationMs / 1000.0,
+        requestTrackingOnStart: requestTrackingOnStart,
+        presenceHeartbeatInterval: presenceHeartbeatIntervalMs / 1000.0
       )
       self.sdk.delegate = self
       self.configured = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -8,7 +8,9 @@ export interface Spec extends TurboModule {
     maxQueuedPayloads: number,
     periodicReconciliationEnabled: boolean,
     periodicReconciliationIntervalMs: number,
-    periodicScanDurationMs: number
+    periodicScanDurationMs: number,
+    presenceHeartbeatIntervalMs: number,
+    requestTrackingOnStart: boolean
   ): Promise<void>;
 
   startScanning(): Promise<void>;

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -48,6 +48,8 @@ export interface Spec extends TurboModule {
   getAuthorizationStatus(): Promise<string>;
   getBluetoothState(): Promise<string>;
   requestLocationAuthorization(level: string): Promise<void>;
+  requestTrackingAuthorization(): Promise<string>;
+  getTrackingAuthorizationStatus(): Promise<string>;
 
   // Persistent detection log written natively (survives termination / captures
   // closed-state events). Returns a JSON string array of entries.

--- a/src/__tests__/sdk.test.ts
+++ b/src/__tests__/sdk.test.ts
@@ -104,7 +104,9 @@ describe('Bearound SDK Core Functions', () => {
         100,
         true,
         20 * 60 * 1000,
-        12_000
+        12_000,
+        5 * 60 * 1000,
+        true
       );
     });
 
@@ -122,7 +124,9 @@ describe('Bearound SDK Core Functions', () => {
         100,
         true,
         20 * 60 * 1000,
-        12_000
+        12_000,
+        5 * 60 * 1000,
+        true
       );
     });
 
@@ -140,6 +144,8 @@ describe('Bearound SDK Core Functions', () => {
         periodicReconciliationEnabled: false,
         periodicReconciliationIntervalMs: 60 * 60 * 1000,
         periodicScanDurationMs: 8_000,
+        presenceHeartbeatIntervalMs: 10 * 60 * 1000,
+        requestTrackingOnStart: false,
       });
 
       expect(mockNativeModule.configure).toHaveBeenCalledWith(
@@ -148,7 +154,9 @@ describe('Bearound SDK Core Functions', () => {
         200,
         false,
         60 * 60 * 1000,
-        8_000
+        8_000,
+        10 * 60 * 1000,
+        false
       );
     });
 
@@ -163,7 +171,9 @@ describe('Bearound SDK Core Functions', () => {
         100,
         true,
         20 * 60 * 1000,
-        12_000
+        12_000,
+        5 * 60 * 1000,
+        true
       );
     });
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -631,6 +631,41 @@ export async function requestLocationAuthorization(
   await Native.requestLocationAuthorization(level);
 }
 
+/** ATT authorisation state. `unavailable` on iOS < 14 and on Android (no such concept). */
+export type TrackingAuthorizationStatus =
+  | 'authorized'
+  | 'denied'
+  | 'restricted'
+  | 'notDetermined'
+  | 'unavailable';
+
+/**
+ * Shows the App Tracking Transparency prompt and, once authorised, the SDK reports the
+ * **IDFA** with every payload. **iOS-only.**
+ *
+ * The SDK never shows this dialog on its own: Apple requires it to appear in a context the
+ * user understands, and an app that prompts at an arbitrary moment gets rejected. Call it at
+ * a point in your onboarding right after explaining why, with the app in the **foreground**
+ * (iOS ignores it otherwise).
+ *
+ * Requires `NSUserTrackingUsageDescription` in your `Info.plist` — without that key iOS shows
+ * no dialog at all and the status stays `notDetermined` forever.
+ *
+ * Answering is a one-time event per install: later calls return the stored decision with no
+ * UI, so it is safe to call on every launch.
+ *
+ * On **Android there is no prompt** — the user's choice lives in system settings and the
+ * platform enforces it — so this resolves `'unavailable'`.
+ */
+export async function requestTrackingAuthorization(): Promise<TrackingAuthorizationStatus> {
+  return (await Native.requestTrackingAuthorization()) as TrackingAuthorizationStatus;
+}
+
+/** Reads the ATT status **without** prompting. Android: always `'unavailable'`. */
+export async function getTrackingAuthorizationStatus(): Promise<TrackingAuthorizationStatus> {
+  return (await Native.getTrackingAuthorizationStatus()) as TrackingAuthorizationStatus;
+}
+
 // --- Foreground-service scanning (Android-only) ---
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,29 @@ export type SdkConfig = {
    * 3–30s on Android.
    */
   periodicScanDurationMs?: number;
+  /**
+   * How often a scan that found NOTHING still reports in, in milliseconds.
+   * Default: 5 min (300_000).
+   *
+   * A scan that finds no beacon and no peer is data too: the device was there and
+   * saw nothing. Those payloads carry the device's own location and the Wi-Fi it
+   * can see — without them the backend cannot tell "no coverage here" apart from
+   * "the app was not running". Only the upload is throttled; scanning is unchanged.
+   *
+   * Native range: 1 min to 1 h (out-of-range values are clamped with a warning).
+   * Pass `0` to turn the empty-scan report off.
+   */
+  presenceHeartbeatIntervalMs?: number;
+  /**
+   * iOS only. Lets the SDK raise the App Tracking Transparency prompt by itself
+   * shortly after `configure()`. Default: true.
+   *
+   * Pass `false` to own the moment — show your own explainer first, or prompt
+   * deeper into onboarding — and call `requestTrackingAuthorization()` yourself.
+   * Nothing is shown unless the app declares `NSUserTrackingUsageDescription`.
+   * Ignored on Android.
+   */
+  requestTrackingOnStart?: boolean;
 };
 
 /**
@@ -405,6 +428,8 @@ export async function configure(config: SdkConfig) {
     periodicReconciliationEnabled = true,
     periodicReconciliationIntervalMs = 20 * 60 * 1000,
     periodicScanDurationMs = 12_000,
+    presenceHeartbeatIntervalMs = 5 * 60 * 1000,
+    requestTrackingOnStart = true,
   } = config;
 
   if (!businessToken || businessToken.trim().length === 0) {
@@ -424,7 +449,9 @@ export async function configure(config: SdkConfig) {
     maxQueuedPayloads,
     periodicReconciliationEnabled,
     periodicReconciliationIntervalMs,
-    periodicScanDurationMs
+    periodicScanDurationMs,
+    presenceHeartbeatIntervalMs,
+    requestTrackingOnStart
   );
 }
 

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -212,6 +212,16 @@ export async function requestForegroundPermissions(): Promise<PermissionResult> 
         'Permissão de Notificações',
         'Usamos notificações para indicar o monitoramento em andamento.'
       );
+      // Android 13+: unlocks the neighbouring access points for the Wi-Fi
+      // observations. Same "Nearby devices" group as BLUETOOTH_SCAN — already
+      // granted above — so the system usually shows no second dialog. Without
+      // it the SDK reports only the connected access point, never its
+      // neighbours, which are what feed the access-point map.
+      await req(
+        PermissionsAndroid.PERMISSIONS.NEARBY_WIFI_DEVICES,
+        'Permissão de dispositivos por perto',
+        'Usamos as redes Wi-Fi visíveis para melhorar a precisão de localização.'
+      );
     }
     return checkPermissions();
   }


### PR DESCRIPTION
Brings the React Native wrapper to parity with the 3.8.0 native SDKs (iOS 3.8.0 / Android 3.8.0).

## What the native SDKs added

A scan that finds no beacons now still reports, carrying whatever the device *can*
observe — its own location and the surrounding Wi-Fi access points (hashed BSSIDs).
The upload is throttled so an idle device does not sync on every scan cycle.

## Changes here

- **Version pins**: podspec, `android/build.gradle` and `package.json` → `3.8.0`.
- **`SdkConfig` / `configure()`** gained two optional fields, both defaulted so existing
  integrations are unaffected:
  - `presenceHeartbeatIntervalMs` (default `300000`) — how often a scan with nothing
    found may report. `0` disables it. Clamped natively to 1 min–1 h.
  - `requestTrackingOnStart` (default `true`) — iOS only; the Android side ignores it,
    since ATT does not exist there.
  Threaded through all five codegen layers: TS type, TurboModule Spec, the Obj-C++
  bridge, Swift and Kotlin.
- **`android/src/main/AndroidManifest.xml`**: the file was empty, so the wrapper relied on
  the host app declaring everything. It now declares `ACCESS_WIFI_STATE` and
  `NEARBY_WIFI_DEVICES` (`usesPermissionFlags="neverForLocation"`) — without them the
  runtime request is denied instantly, with no dialog.
- **iOS example**: `NSUserTrackingUsageDescription` in `Info.plist` and
  `com.apple.developer.networking.wifi-info` in the entitlements.
- Tests and CHANGELOG updated.

## Validation

`yarn test` → 148 passing. Typecheck clean. `yarn check:versions` →
"Aligned: native line 3.8 (iOS 3.8.0 / Android 3.8.0); RN major 3 mirrors native major 3."

The example app cannot be compiled against the published Android artifact yet: the
JitPack build for `v3.8.0` is failing on their runners with
`UnknownHostException: services.gradle.org` — the runner has no working DNS, so it
cannot even download Gradle. Nothing in this repository or in the Android SDK affects
that; the build has to be re-cut once JitPack recovers.