### PR TITLE
chore: bump version to 3.8.1

### DIFF
--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.8.0"
+  s.dependency "BearoundSDK", "3.8.1"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.8.1
+
+### Changed
+- Native SDKs pinned to **3.8.1**, which carries the fix for `encounter_mesh` and
+  `presence_heartbeat` never reaching the payload — until now every beacon-less upload was
+  labelled as an ordinary timer sync, so a presence report was indistinguishable from a
+  regular one on the backend.
+
 ## 3.8.0
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.6.2 adds the persisted detection log with app-state tagging
   // (getDetectionLogJson/clearDetectionLog, 1:1 with iOS), on top of the 3.6.x
   // line (telemetry handoff, ghost-beacon fixes, scan watchdog).
-  implementation 'com.github.Bearound:bearound-android-sdk:3.8.0'
+  implementation 'com.github.Bearound:bearound-android-sdk:3.8.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
Pins the native SDKs to **3.8.1**.

## Why

3.8.1 carries the fix for `encounter_mesh` and `presence_heartbeat` **never reaching the
payload**. Until now every beacon-less upload — an encounter batch, or a scan that found
nothing and reported where the device was — went out labelled as an ordinary timer sync, so
a presence report was indistinguishable from a regular one on the backend. That distinction
is the reason the 3.8 line exists.

## Verified on-device against the published 3.8.1

Both examples built against the pod/artifact from CocoaPods and JitPack (no local Maven, no
dev pod), running release builds with no debugger attached:

| | payloads | with beacon | triggers observed |
| --- | --- | --- | --- |
| Flutter | 32 | 22 | `presence_heartbeat`, `encounter_mesh`, and composed forms |
| React Native | 38 | 30 | `presence_heartbeat+stop_scanning`, `encounter_mesh+foreground_flush` |

Both now emit the two triggers the native SDK emits — previously neither ever appeared.