### PR TITLE
docs: wi-fi em background exige permissão a mais em cada plataforma

### DIFF
--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -122,6 +122,18 @@ Guardrails — follow strictly:
   keeps working); the on-device permission grants (Always location + Background App
   Refresh); and the Google Play connectedDevice foreground-service declaration + demo
   video. Do not attempt those yourself.
+- Wi-Fi observations in the BACKGROUND need one more grant on each platform, and its
+  absence is INVISIBLE — the system returns empty instead of an error. Android: without
+  ACCESS_BACKGROUND_LOCATION a backgrounded app gets an empty scan list and the
+  placeholder BSSID 02:00:00:00:00:00, so wifis[] arrives empty (measured: 25 access
+  points to zero the instant the app was backgrounded). iOS: .whenInUse stops revealing
+  the access point in the background; .always keeps it. Neither is needed for beacon
+  detection, and on Android it costs a Google Play policy review plus a demo video. So
+  ASK ME whether background Wi-Fi matters for this app. If yes, call
+  requestBackgroundLocation() AFTER foreground location is granted (Android 11+ refuses
+  both in one dialog) and use .always on iOS. If no, leave it out — valid choice, just
+  not a silent one. Verify either way in the payload:
+  device.permissions.backgroundLocation.
 ```
 
 Web-capable agents can fetch this prompt directly from its raw URL:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,35 @@ on both platforms.
 Nothing degrades if you skip the iOS capability: the field is simply omitted and every other
 feature behaves the same.
 
+> ### ⚠️ Sem permissão de background, o Wi-Fi só é coletado com o app aberto
+>
+> A tabela acima cobre **o que desbloqueia** a coleta. Ela não cobre **por quanto tempo** —
+> e essa é a parte que surpreende.
+>
+> - **Android:** a partir do 10, um app em background sem `ACCESS_BACKGROUND_LOCATION`
+>   recebe lista de scan vazia e o BSSID placeholder `02:00:00:00:00:00`. Não é erro, não
+>   é exceção: o SDK descarta o placeholder e `wifis[]` chega vazio. Medido em produção —
+>   **25 pontos de acesso viraram zero no instante em que o app foi para background**, com
+>   todas as permissões que ele pediu concedidas.
+> - **iOS:** com `.whenInUse` o sistema para de revelar o access point em background e
+>   retorna `nil`. `.always` é o que mantém a coleta viva.
+>
+> Como uma frota passa quase todo o tempo em background, "só em foreground" na prática
+> significa **quase nunca** — e um teste manual com o app aberto passa perfeitamente.
+>
+> No Android, `requestPermissions()` **não** pede background location de propósito: é
+> permissão *dangerous*, com revisão de política da Play e vídeo de demonstração
+> atrelados. Se você contribui para o mapa de pontos de acesso, peça explicitamente:
+>
+> ```typescript
+> import { requestBackgroundLocation } from '@bearound/react-native-sdk';
+>
+> // só DEPOIS que a localização de foreground já foi concedida
+> const ok = await requestBackgroundLocation();
+> ```
+>
+> Confira o resultado no payload: `device.permissions.backgroundLocation`.
+
 ## Presence heartbeat
 
 Until 3.8.0 a device that saw no beacon and no other SDK device stayed silent, and the

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -15,8 +15,14 @@
  * - **Android ≤ 11 (API ≤ 30):** fine/coarse location gates the BLE scan.
  * - `POST_NOTIFICATIONS` (Android 13+): optional, for foreground-service /
  *   monitoring indicators — not required to scan.
- * - `ACCESS_BACKGROUND_LOCATION`: NOT a scan requirement; requested only via the
- *   explicit {@link requestBackgroundLocation} opt-in.
+ * - `ACCESS_BACKGROUND_LOCATION`: NOT a scan requirement — but it IS what keeps Wi-Fi
+ *   observations coming once the app is backgrounded. Without it, from Android 10 on, a
+ *   backgrounded app gets an empty scan list and the placeholder BSSID
+ *   `02:00:00:00:00:00`; the SDK discards the placeholder, so `wifis[]` and
+ *   `network.apId` simply arrive empty, with no error anywhere. Measured in production:
+ *   25 access points dropped to zero the instant the app was backgrounded. Requested
+ *   only via the explicit {@link requestBackgroundLocation} opt-in — see its docs before
+ *   deciding.
  *
  * @author Bearound Team
  */
@@ -263,6 +269,16 @@ export async function requestForegroundPermissions(): Promise<PermissionResult> 
  *
  * This never opens app Settings on your behalf; if the return value indicates
  * a permanent denial the host app decides whether to route the user there.
+ *
+ * **When you actually need this.** Beacon detection never does — on Android 12+ the SDK
+ * scans on `BLUETOOTH_SCAN`, with no location at all. Wi-Fi observations do: without this
+ * grant they only work while your app is on screen, and a fleet is almost never on screen.
+ * If you are contributing to the access-point map, this is the difference between
+ * collecting and not collecting.
+ *
+ * **What it costs.** It is a dangerous permission with a Google Play policy review and a
+ * demonstration video attached. Skipping it is a legitimate choice — just not a silent
+ * one. Check the outcome in the payload: `device.permissions.backgroundLocation`.
  *
  * @returns Promise<boolean> true if background location permission is granted
  *


### PR DESCRIPTION
A doc do módulo afirmava que `ACCESS_BACKGROUND_LOCATION` **"NÃO é requisito de scan"**.

Verdade para beacon — no Android 12+ o SDK escaneia em `BLUETOOTH_SCAN`, sem location nenhuma. **Falso para Wi-Fi**, e a diferença é invisível.

Sem ele, do Android 10 em diante, app em background recebe **lista de scan vazia** e o BSSID placeholder `02:00:00:00:00:00`. O SDK descarta o placeholder — e tem de descartar, senão todo aparelho do mundo vira o mesmo AP. Então `wifis[]` e `network.apId` chegam vazios, sem erro em lugar nenhum.

Medido em produção, com corte no instante exato:

```
fg=True    wifis=25   apId=2dc5d744…
fg=False   wifis=0    apId=None
```

Mesmo aparelho, mesma sessão, todas as permissões que ele pediu concedidas.

No iOS o equivalente é `.whenInUse` contra `.always`.

## O que muda

Só documentação. **Nenhuma mudança de comportamento.**

- **`permissions.ts`** — o cabeçalho do módulo e o doc de `requestBackgroundLocation` passam a explicar quando isso importa e o que custa
- **README** — aviso na seção de Wi-Fi, cobrindo as duas plataformas
- **AI-AGENT-SETUP** — passa a mandar **perguntar** em vez de omitir

## O que continua igual

`requestPermissions()` **não** pede background location. É permissão *dangerous*, com revisão de política da Play e vídeo de demonstração atrelados, e não é requisito de detecção. Continua opt-in explícito via `requestBackgroundLocation()`.

O que muda é o integrador **saber o que perde** ao pular — hoje a doc dizia que não perdia nada.

Espelha [bearound-android-sdk#82](https://github.com/Bearound/bearound-android-sdk/pull/82) e [bearound-ios-sdk#72](https://github.com/Bearound/bearound-ios-sdk/pull/72).

`tsc --noEmit`, lint e commitlint limpos.
