### PR TITLE
chore: version 3.8.2

### DIFF
--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.8.1"
+  s.dependency "BearoundSDK", "3.8.2"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [3.8.2]
 
 ### Added
 - **Expo config plugin.** `["@bearound/react-native-sdk", { … }]` in `app.json` now applies the
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `apsEnvironment`, `appDelegate`.
 
 ### Fixed
+
+- **The iOS Bluetooth alert no longer pops up over other apps** (BearoundSDK 3.8.2). Both
+  `CBCentralManager` instances in the native iOS SDK were created without
+  `CBCentralManagerOptionShowPowerAlertKey`, which defaults to `true`: with the radio off or
+  the Bluetooth permission denied, iOS answered that instantiation with its own alert. Because
+  the SDK wakes in the **background**, the alert surfaced on top of whatever app the user had
+  open — the host app's name showing up in an alert while the user was somewhere else. Nothing
+  changes functionally: scanning was already gated on the radio being powered on, so a user
+  with Bluetooth off simply doesn't scan — now silently. The first-time authorization prompt
+  is a different mechanism and is unaffected.
 - **iOS build on React Native 0.86** (the version Expo SDK 57 ships). RN 0.86 delivers
   React-Core as a prebuilt framework whose umbrella header pulls in non-modular headers, and
   compiling this pod's generated `-Swift.h` against it failed with *"include of non-modular

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bearound/react-native-sdk",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "bearound",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
Sobe o pin do `BearoundSDK` para **3.8.2** — a correção do alerta de Bluetooth do iOS aparecendo por cima de outros apps. Também publica o **Expo config plugin** (#38), que estava mergeado mas nunca saiu no npm.

**O que muda para o app que usa o wrapper:** com o Bluetooth desligado (ou a permissão negada), o iOS para de mostrar o alerta do sistema enquanto o usuário está em outro app. Nada muda funcionalmente — o scan já era gateado no rádio ligado.

Carriers de versão:
- `package.json` → 3.8.2 (o `ci-cd.yaml` compara com a tag)
- `BearoundReactSdk.podspec` → `BearoundSDK 3.8.2`
- `CHANGELOG.md`: `## Unreleased` virou `## [3.8.2]`

Android segue em 3.8.1 de propósito — o fix é iOS-only e o `check:versions` permite o dígito de patch diferente dentro da mesma linha minor (`✅ Aligned: native line 3.8`).