### PR TITLE
feat(privacy): expose the data-collection switches through the bridge

### DIFF
--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -90,6 +90,14 @@ EXPO ROUTE (replaces steps 1, 2 and 3):
    Include NSUserTrackingUsageDescription: without that key iOS never shows the App
    Tracking Transparency prompt, so the SDK reports no advertising identifier — and
    nothing errors, the field is simply never there.
+   If this app collects the advertising identifier for ITS OWN purposes but must NOT
+   share it with Bearound, pass configure({ collectAdvertisingId: false }): the SDK
+   then never reads it and iOS never raises the prompt, whatever the plist says. Same
+   switch shape for the other two personal signals: collectLocation: false drops the
+   device's coordinates from the payload (beacon detection is UNAFFECTED on both
+   platforms) and collectWifi: false drops the access points. All three default to
+   true; ASK ME before turning any of them off — it is a data decision, not a
+   technical one.
 
 4. JS — configure, THEN request permissions, THEN scan (order matters; follow the
    README Quick Start): on root-component mount call

--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -90,14 +90,14 @@ EXPO ROUTE (replaces steps 1, 2 and 3):
    Include NSUserTrackingUsageDescription: without that key iOS never shows the App
    Tracking Transparency prompt, so the SDK reports no advertising identifier — and
    nothing errors, the field is simply never there.
-   If this app collects the advertising identifier for ITS OWN purposes but must NOT
-   share it with Bearound, pass configure({ collectAdvertisingId: false }): the SDK
-   then never reads it and iOS never raises the prompt, whatever the plist says. Same
-   switch shape for the other two personal signals: collectLocation: false drops the
-   device's coordinates from the payload (beacon detection is UNAFFECTED on both
-   platforms) and collectWifi: false drops the access points. All three default to
-   true; ASK ME before turning any of them off — it is a data decision, not a
-   technical one.
+   Data-collection switches — leave them OUT of configure(). The defaults collect
+   everything (collectAdvertisingId, collectLocation and collectWifi are all true) and
+   that is what you ship. Do NOT ask me what to collect and do NOT write these
+   arguments. Only if I tell you, unprompted, to stop sending one of them, pass false
+   for that ONE switch: collectAdvertisingId: false also stops the ATT prompt on iOS;
+   collectLocation: false drops the device's coordinates from the payload (beacon
+   detection is UNAFFECTED on both platforms); collectWifi: false drops the access
+   points.
 
 4. JS — configure, THEN request permissions, THEN scan (order matters; follow the
    README Quick Start): on root-component mount call

--- a/BearoundReactSdk.podspec
+++ b/BearoundReactSdk.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   
   # Exact pin, kept in lockstep with the Android gradle dep (same native release).
   # Bumping is a deliberate, guarded step — see scripts/check-native-versions.mjs.
-  s.dependency "BearoundSDK", "3.8.2"
+  s.dependency "BearoundSDK", "3.9.0"
 
   s.frameworks = "CoreBluetooth", "CoreLocation", "UIKit", "Foundation"
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Aligned with Bearound native SDKs **3.8.0** (exact pins live in `android/build.g
 * [Wi-Fi observations](#wi-fi-observations)
 * [Presence heartbeat](#presence-heartbeat)
 * [Advertising identifier (IDFA / AAID)](#advertising-identifier-idfa--aaid)
+* [Controlling what the SDK collects](#controlling-what-the-sdk-collects)
 * [Scan modes (Android)](#scan-modes-android)
 * [iOS Background Integration (required)](#ios-background-integration-required)
 * [Quick Start](#quick-start)
@@ -384,7 +385,8 @@ BeAround.configure({
 Two things it does **not** do. It never throttles **scanning** — only the upload, so
 detection latency is untouched. And it sends nothing when there is neither a location fix
 nor an access point to report: an app that grants no permissions keeps sending exactly what
-it sent before.
+it sent before — and so does one that turned both signals off in
+[`configure`](#controlling-what-the-sdk-collects).
 
 ## Advertising identifier (IDFA / AAID)
 
@@ -424,6 +426,53 @@ implementation 'com.google.android.gms:play-services-ads-identifier:18.2.0'
 > declare **Tracking** in your App Store privacy label; the `AD_ID` permission obliges you to
 > tick **"Device or other IDs"** in the Play Data Safety form. Apps for children must strip
 > `AD_ID` (Play Families policy).
+
+If your app collects the advertising identifier for its own purposes but you do not want it
+sent to Bearound, pass `collectAdvertisingId: false` — see
+[Controlling what the SDK collects](#controlling-what-the-sdk-collects).
+
+## Controlling what the SDK collects
+
+Three of the signals in the payload describe the **person**, not the sighting: the
+advertising identifier (IDFA on iOS, AAID on Android), the device's own coordinates, and the
+Wi-Fi access points around it. Your app may collect them for its own purposes and still not
+want to share them with Bearound — a different legal basis, a store declaration you do not
+want to extend, or a client policy that simply says no.
+
+Each one has a switch in `configure(...)`, on both platforms:
+
+```ts
+await configure({
+  businessToken: 'your-business-token-here',
+  collectAdvertisingId: false, // default: true — my app collects the IDFA/AAID, but don't send it
+  collectLocation: false,      // default: true — don't send the device's coordinates
+  collectWifi: true,           // default: true
+});
+```
+
+**All three default to `true`**, so an integration that does not mention them keeps behaving
+exactly as it does today.
+
+A switch turned off means **collect nothing**, not "collect and withhold": the value is never
+read from the platform in the first place.
+
+| Switch | What disappears from the payload | Also |
+|--------|----------------------------------|------|
+| `collectAdvertisingId: false` | `device.permissions.advertisingId`, plus `trackingAuthorization` (iOS) / `limitAdTracking` (Android) | iOS never raises the App Tracking Transparency prompt — not on start, and `requestTrackingAuthorization()` just reports the current status. Android never queries Play Services for the id |
+| `collectLocation: false` | the top-level `location` block | `device.permissions.location` / `locationAccuracy` **stay** — they report the authorisation the user granted, not where they are |
+| `collectWifi: false` | the top-level `wifis` array, `device.network.apId`, `device.network.wifiSSID` | No Wi-Fi read is issued at all |
+
+**Beacon detection is never affected.** On iOS region monitoring is the background wake-up
+mechanism, not a data source; on Android the location permission BLE scanning requires is
+about radio access. With `collectLocation: false` the SDK still wakes, still detects and
+still reports beacons — it just stops saying *where* the device was.
+
+What it does affect is the [presence heartbeat](#presence-heartbeat): a scan that found
+nothing only reports in when it has a location or an access point to carry. Turn both off and
+there is nothing left to report, so the heartbeat stops firing — by design.
+
+The choice is persisted with the rest of the configuration, so it survives the background
+relaunches both systems perform on the SDK's behalf.
 
 ## Scan modes (Android)
 
@@ -938,6 +987,14 @@ export type SdkConfig = {
   // iOS only: shows the App Tracking Transparency prompt when scanning starts, which is
   // what unlocks the IDFA. Android has no such prompt and ignores this.
   requestTrackingOnStart?: boolean; // default: true
+
+  // What the SDK may collect at all. Each switch turned off means the value is never
+  // READ from the platform, not just withheld — and collectAdvertisingId: false also
+  // keeps iOS from ever raising the ATT prompt. Beacon detection is unaffected by
+  // collectLocation: false. See "Controlling what the SDK collects".
+  collectAdvertisingId?: boolean; // default: true
+  collectLocation?: boolean; // default: true
+  collectWifi?: boolean; // default: true
 };
 
 export type UserProperties = {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,5 +79,5 @@ dependencies {
   // v3.6.2 adds the persisted detection log with app-state tagging
   // (getDetectionLogJson/clearDetectionLog, 1:1 with iOS), on top of the 3.6.x
   // line (telemetry handoff, ghost-beacon fixes, scan watchdog).
-  implementation 'com.github.Bearound:bearound-android-sdk:3.8.1'
+  implementation 'com.github.Bearound:bearound-android-sdk:3.9.0'
 }

--- a/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
+++ b/android/src/main/java/com/bearoundreactsdk/BearoundReactSdkModule.kt
@@ -127,6 +127,9 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
     // Part of the cross-platform signature (the codegen spec is shared), but App
     // Tracking Transparency is iOS-only — read and dropped here on purpose.
     requestTrackingOnStart: Boolean,
+    collectAdvertisingId: Boolean,
+    collectLocation: Boolean,
+    collectWifi: Boolean,
     promise: Promise
   ) {
     try {
@@ -154,7 +157,10 @@ class BearoundReactSdkModule(private val ctx: ReactApplicationContext) :
         periodicReconciliationEnabled = periodicReconciliationEnabled,
         periodicReconciliationIntervalMillis = periodicReconciliationIntervalMs.toLong(),
         periodicScanDurationMillis = periodicScanDurationMs.toLong(),
-        presenceHeartbeatIntervalMillis = presenceHeartbeatIntervalMs.toLong()
+        presenceHeartbeatIntervalMillis = presenceHeartbeatIntervalMs.toLong(),
+        collectAdvertisingId = collectAdvertisingId,
+        collectLocation = collectLocation,
+        collectWifi = collectWifi
       )
 
       if (wasScanning) {

--- a/ios/BearoundReactSdk.mm
+++ b/ios/BearoundReactSdk.mm
@@ -21,6 +21,9 @@ periodicReconciliationIntervalMs:(double)periodicReconciliationIntervalMs
 periodicScanDurationMs:(double)periodicScanDurationMs
 presenceHeartbeatIntervalMs:(double)presenceHeartbeatIntervalMs
 requestTrackingOnStart:(BOOL)requestTrackingOnStart
+collectAdvertisingId:(BOOL)collectAdvertisingId
+   collectLocation:(BOOL)collectLocation
+       collectWifi:(BOOL)collectWifi
           resolve:(RCTPromiseResolveBlock)resolve
            reject:(RCTPromiseRejectBlock)reject
 {
@@ -40,7 +43,10 @@ requestTrackingOnStart:(BOOL)requestTrackingOnStart
       periodicReconciliationIntervalMs:periodicReconciliationIntervalMs
                 periodicScanDurationMs:periodicScanDurationMs
            presenceHeartbeatIntervalMs:presenceHeartbeatIntervalMs
-                requestTrackingOnStart:requestTrackingOnStart];
+                requestTrackingOnStart:requestTrackingOnStart
+                  collectAdvertisingId:collectAdvertisingId
+                       collectLocation:collectLocation
+                           collectWifi:collectWifi];
   resolve(nil);
 }
 

--- a/ios/RNBearoundBridge.swift
+++ b/ios/RNBearoundBridge.swift
@@ -72,7 +72,10 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
     periodicReconciliationIntervalMs: Double,
     periodicScanDurationMs: Double,
     presenceHeartbeatIntervalMs: Double,
-    requestTrackingOnStart: Bool
+    requestTrackingOnStart: Bool,
+    collectAdvertisingId: Bool,
+    collectLocation: Bool,
+    collectWifi: Bool
   ) {
     DispatchQueue.main.async {
       let precision = self.mapToScanPrecision(scanPrecision)
@@ -94,7 +97,10 @@ public class RNBearoundBridge: NSObject, CLLocationManagerDelegate, CBCentralMan
         periodicReconciliationInterval: periodicReconciliationIntervalMs / 1000.0,
         periodicScanDuration: periodicScanDurationMs / 1000.0,
         requestTrackingOnStart: requestTrackingOnStart,
-        presenceHeartbeatInterval: presenceHeartbeatIntervalMs / 1000.0
+        presenceHeartbeatInterval: presenceHeartbeatIntervalMs / 1000.0,
+        collectAdvertisingId: collectAdvertisingId,
+        collectLocation: collectLocation,
+        collectWifi: collectWifi
       )
       self.sdk.delegate = self
       self.configured = true

--- a/src/NativeBearoundReactSdk.ts
+++ b/src/NativeBearoundReactSdk.ts
@@ -10,7 +10,10 @@ export interface Spec extends TurboModule {
     periodicReconciliationIntervalMs: number,
     periodicScanDurationMs: number,
     presenceHeartbeatIntervalMs: number,
-    requestTrackingOnStart: boolean
+    requestTrackingOnStart: boolean,
+    collectAdvertisingId: boolean,
+    collectLocation: boolean,
+    collectWifi: boolean
   ): Promise<void>;
 
   startScanning(): Promise<void>;

--- a/src/__tests__/sdk.test.ts
+++ b/src/__tests__/sdk.test.ts
@@ -106,6 +106,9 @@ describe('Bearound SDK Core Functions', () => {
         20 * 60 * 1000,
         12_000,
         5 * 60 * 1000,
+        true,
+        true,
+        true,
         true
       );
     });
@@ -126,6 +129,9 @@ describe('Bearound SDK Core Functions', () => {
         20 * 60 * 1000,
         12_000,
         5 * 60 * 1000,
+        true,
+        true,
+        true,
         true
       );
     });
@@ -146,6 +152,9 @@ describe('Bearound SDK Core Functions', () => {
         periodicScanDurationMs: 8_000,
         presenceHeartbeatIntervalMs: 10 * 60 * 1000,
         requestTrackingOnStart: false,
+        collectAdvertisingId: false,
+        collectLocation: false,
+        collectWifi: false,
       });
 
       expect(mockNativeModule.configure).toHaveBeenCalledWith(
@@ -156,7 +165,35 @@ describe('Bearound SDK Core Functions', () => {
         60 * 60 * 1000,
         8_000,
         10 * 60 * 1000,
+        false,
+        false,
+        false,
         false
+      );
+    });
+
+    it('should forward each data-collection switch independently', async () => {
+      const { configure } = require('../index');
+
+      await configure({
+        businessToken: 'test-token',
+        collectAdvertisingId: false,
+      });
+
+      // Only the advertising id goes off; a copy/paste slip in the positional
+      // argument list would otherwise take location and Wi-Fi down with it.
+      expect(mockNativeModule.configure).toHaveBeenCalledWith(
+        'test-token',
+        'high',
+        100,
+        true,
+        20 * 60 * 1000,
+        12_000,
+        5 * 60 * 1000,
+        true,
+        false,
+        true,
+        true
       );
     });
 
@@ -173,6 +210,9 @@ describe('Bearound SDK Core Functions', () => {
         20 * 60 * 1000,
         12_000,
         5 * 60 * 1000,
+        true,
+        true,
+        true,
         true
       );
     });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,6 +70,40 @@ export type SdkConfig = {
    * Ignored on Android.
    */
   requestTrackingOnStart?: boolean;
+  /**
+   * Whether the SDK may read and report the advertising identifier (IDFA on iOS,
+   * AAID on Android). Default: true.
+   *
+   * `false` means it is never read and never leaves the device:
+   * `device.permissions.advertisingId` (plus `trackingAuthorization` / `limitAdTracking`)
+   * is absent from every payload, iOS never raises the App Tracking Transparency prompt —
+   * not on start, and `requestTrackingAuthorization()` only reports the current status —
+   * and Android never queries Play Services for the id.
+   *
+   * For an app that collects the identifier for its own purposes but does not want to
+   * share it with Bearound.
+   */
+  collectAdvertisingId?: boolean;
+  /**
+   * Whether the SDK may report the device's own location. Default: true.
+   *
+   * `false` means the cached/last-known fix is never read and the top-level `location`
+   * block is absent from every payload. `device.permissions.location` /
+   * `locationAccuracy` stay — they describe the authorisation, not the position.
+   *
+   * Beacon detection is NOT affected: on iOS region monitoring is the background wake-up
+   * mechanism, on Android the location permission BLE scanning needs is about radio
+   * access. The SDK keeps detecting and reporting beacons; it just stops saying where the
+   * device was.
+   */
+  collectLocation?: boolean;
+  /**
+   * Whether the SDK may report the Wi-Fi access points around the device. Default: true.
+   *
+   * `false` means no Wi-Fi read is issued and the top-level `wifis` array plus
+   * `device.network.apId` / `device.network.wifiSSID` are absent from every payload.
+   */
+  collectWifi?: boolean;
 };
 
 /**
@@ -430,6 +464,11 @@ export async function configure(config: SdkConfig) {
     periodicScanDurationMs = 12_000,
     presenceHeartbeatIntervalMs = 5 * 60 * 1000,
     requestTrackingOnStart = true,
+    // Data-collection switches default ON: an integration that never mentions them keeps
+    // sending exactly what it sends today.
+    collectAdvertisingId = true,
+    collectLocation = true,
+    collectWifi = true,
   } = config;
 
   if (!businessToken || businessToken.trim().length === 0) {
@@ -451,7 +490,10 @@ export async function configure(config: SdkConfig) {
     periodicReconciliationIntervalMs,
     periodicScanDurationMs,
     presenceHeartbeatIntervalMs,
-    requestTrackingOnStart
+    requestTrackingOnStart,
+    collectAdvertisingId,
+    collectLocation,
+    collectWifi
   );
 }
 


### PR DESCRIPTION
Forwards the native SDKs' new `collectAdvertisingId` / `collectLocation` / `collectWifi` to JS,
**all defaulting to `true`**, so an integration that does not mention them behaves exactly as
before.

```ts
await configure({
  businessToken: '…',
  collectAdvertisingId: false,
  collectLocation: false,
  collectWifi: true,
});
```

An app can collect the advertising identifier, the device location or the Wi-Fi around it for
its own purposes and still need to keep them out of what it sends here. Turning a switch off
means the value is never read from the platform in the first place, and on iOS it also keeps the
SDK from raising the App Tracking Transparency prompt.

Three new positional arguments on the codegen spec, threaded through all three native surfaces:
the ObjC++ TurboModule, `RNBearoundBridge` (Swift) and the Android module. Android reads and
forwards them — unlike `requestTrackingOnStart`, these are **not** iOS-only.

### Not affected

Beacon detection is untouched by `collectLocation: false` — region monitoring (iOS) and the
location permission BLE scanning needs (Android) are wake-up and radio access, not coordinate
reporting.

The presence heartbeat **does** stop when both location and Wi-Fi are off: it would have nothing
to carry.

### Depends on

The native SDKs that ship these parameters (iOS > 3.8.2, Android > 3.8.1). The pins in the
podspec and `android/build.gradle` are bumped at release time — this PR does not compile against
the currently published natives.

### Tests

The three `configure` assertions carry the new tail, plus one proving a single switch travels
alone (a slip in the positional list would otherwise be invisible). `jest` 172/172, `tsc` and
`eslint` clean.
